### PR TITLE
Support prebuilt development VM WorkspaceTemplates

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -242,6 +242,18 @@ Selected template and Project revisions are captured at admission; source edits
 do not change existing execution snapshots. Children keep their existing
 workspace inheritance.
 
+VM WorkspaceTemplates support prebuilt `environment.image` references and
+`resources: {cpu: 12, memory: 24Gi, storage: 120Gi}`. CPU is a whole core count;
+memory/storage use `Mi`, `Gi`, or `Ti`. The controller applies its rootdisk
+minimum to storage requests. Pin images by digest for reproducible selection.
+Only the existing `IfNotPresent`/`Reuse` disk import/clone behavior is supported;
+preparation, initialization and retained-template instances remain separate work.
+Images must implement the SRW VM guest/SSH contract. See the
+[development VM template](../examples/manifests/srw-development-vm.yaml) and
+[selection examples](../examples/manifests/README.md#execution-owned-workspace-selection).
+The selected VM image/resources are captured with execution policy, independently
+of the typed harness settings, and reused for Job dispatch and Session resume.
+
 Bundled Experts now declare advisory preferences. For stored SRW Experts, run
 `scripts/migrate-workspace-preferences.py` to preview versioned changes, then
 `--apply --plan-revision <returned-revision>` against the intended database.

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -131,7 +131,8 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Bake tokenizer assets before source changes. Runtime counting must not block
 # the event loop on lazy downloads or fall back because an asset is missing.
 ENV TIKTOKEN_CACHE_DIR=/opt/tiktoken-cache
-COPY docker/prepare-tokenizer-cache.py /usr/local/bin/prepare-tokenizer-cache.py
+# Private workspace checkouts can be mode 0600; the final srw user must read it.
+COPY --chmod=0644 docker/prepare-tokenizer-cache.py /usr/local/bin/prepare-tokenizer-cache.py
 RUN python /usr/local/bin/prepare-tokenizer-cache.py prepare
 
 # No browser in the agent image — Chromium lives on the workspace image only

--- a/docker/Dockerfile.agent.dev
+++ b/docker/Dockerfile.agent.dev
@@ -145,7 +145,8 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Bake tokenizer assets before source changes. Runtime counting must not block
 # the event loop on lazy downloads or fall back because an asset is missing.
 ENV TIKTOKEN_CACHE_DIR=/opt/tiktoken-cache
-COPY docker/prepare-tokenizer-cache.py /usr/local/bin/prepare-tokenizer-cache.py
+# Private workspace checkouts can be mode 0600; the final srw user must read it.
+COPY --chmod=0644 docker/prepare-tokenizer-cache.py /usr/local/bin/prepare-tokenizer-cache.py
 RUN python /usr/local/bin/prepare-tokenizer-cache.py prepare
 
 # No browser in the agent image — Chromium lives on the workspace image only

--- a/docker/Dockerfile.workspace
+++ b/docker/Dockerfile.workspace
@@ -221,8 +221,8 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 #     SSH (exec_command), so Chrome's CDP stays on the workspace loopback and
 #     never crosses the pod network. See knowledge-base/knowledge/features/browser_workspace_executor.md
 # ---------------------------------------------------------------------------
-COPY docker/browser-exec /usr/local/bin/browser-exec
-RUN chmod +x /usr/local/bin/browser-exec
+# The workspace user needs read and execute access even from a private checkout.
+COPY --chmod=0755 docker/browser-exec /usr/local/bin/browser-exec
 
 # ---------------------------------------------------------------------------
 # 2d. Browser stack conformance gate — the SAME script the VM golden image runs
@@ -233,10 +233,9 @@ RUN chmod +x /usr/local/bin/browser-exec
 #     See knowledge-base/knowledge/issues/vm_workspace_missing_browser_exec.md. Installed permanently
 #     as well as run, so any live workspace can be interrogated in five seconds.
 # ---------------------------------------------------------------------------
-COPY docker/check-browser-stream.py /usr/local/bin/check-browser-stream
-COPY docker/assert-browser-stack.sh /usr/local/bin/assert-browser-stack
-RUN chmod +x /usr/local/bin/check-browser-stream /usr/local/bin/assert-browser-stack \
-    && /usr/local/bin/assert-browser-stack
+COPY --chmod=0755 docker/check-browser-stream.py /usr/local/bin/check-browser-stream
+COPY --chmod=0755 docker/assert-browser-stack.sh /usr/local/bin/assert-browser-stack
+RUN /usr/local/bin/assert-browser-stack
 
 # ---------------------------------------------------------------------------
 # 3. code-server (IDE)
@@ -399,8 +398,7 @@ RUN cp -a /home/agent-host /etc/skel.agent-host
 # ---------------------------------------------------------------------------
 # 10. Entrypoint — SSHD (foreground) + code-server (background)
 # ---------------------------------------------------------------------------
-COPY docker/workspace-entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY --chmod=0755 docker/workspace-entrypoint.sh /usr/local/bin/entrypoint.sh
 
 EXPOSE 30022 38080 9222
 

--- a/examples/manifests/README.md
+++ b/examples/manifests/README.md
@@ -75,9 +75,48 @@ workspace revisions are frozen in execution snapshots, including across Session
 configuration edits and End/Resume. Unattended Project loops, automations and
 Officer dispatch also resolve the Project workspace before connector selection.
 
-The current SRW provisioner accepts backend-only templates with `Delete`
-retention. It rejects template resources, custom workspace images, initialization,
-preparation, retained instances and `instanceRef` instead of discarding them.
+The SRW provisioner accepts backend-only templates and prebuilt VM templates
+with `Delete` retention. VM templates can select `environment.image` and
+`resources.cpu`, `memory`, and `storage`. CPUs must be whole cores; the disk
+request is raised to the controller's rootdisk minimum when necessary.
+`IfNotPresent`/`Reuse` uses the controller's existing disk import/clone behavior.
+Use immutable image digests: an existing cached golden disk is keyed by the full
+image reference, so changing the contents behind a tag does not invalidate it.
+Other pull/cache policies, preparation, initialization, retained instances and
+`instanceRef` remain unsupported. Image/resource settings on the SRW sandbox
+and virtual backends are also rejected instead of discarded.
+
+[srw-development-vm.yaml](srw-development-vm.yaml) selects a published VM image
+with Docker Engine, Compose, Buildx, kubectl, Helm, k3d, Tilt, mkcert, Python,
+Node and Git already installed. It is a bootable VM disk implementing SRW's
+guest/SSH contract. An application container image cannot be used as a VM disk.
+Applying this template alone creates no VM. An authorized VM Job or Session
+selects it independently of its Expert; the installation must enable the VM tier.
+
+For an MCP-created manifest Job, first use `manifest_apply` on the template,
+then on a Job containing this execution selection:
+
+```yaml
+execution:
+  expert:
+    ref:
+      name: engineer
+      scope: {kind: Catalog, name: shared}
+  workspace:
+    template:
+      ref:
+        name: srw-development
+        scope: {kind: Account, name: me}
+  connectors: {}
+```
+
+Set the Job task to the source revision and work to perform, and attach the
+repository and other required Connectors. Project defaults can select the same
+template for team Jobs. The existing MCP manifest API preserves omitted
+selections and explicit `workspace: null` without an additional selection syntax.
+VM allocation is captured at admission and survives dispatch, Session settings
+edits and resume. Changing a template affects new executions; changing VM image
+or resources through a Session settings PATCH requires a new Session.
 These fields are part of the manifest schema and are supported only where the
 selected provisioner implements them. This change does not add a general
 auto-upgrade policy or preparation cache.

--- a/examples/manifests/srw-development-vm.yaml
+++ b/examples/manifests/srw-development-vm.yaml
@@ -1,0 +1,19 @@
+# A prebuilt VM workspace for building and testing SRW with Docker, k3d and Tilt.
+# This resource stores a recipe; applying it alone does not allocate a VM.
+# Omitted scope uses the authenticated Account (or the CLI's explicit scope).
+apiVersion: srw/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: srw-development
+spec:
+  backend: vm
+  resources:
+    cpu: 12
+    memory: 24Gi
+    storage: 120Gi
+  environment:
+    # Bootable SRW VM disk, published 2026-09-08. Each VM gets its own rootdisk.
+    image: ghcr.io/knaeckebrothero/superhuman-remote-worker-agent-vm-base@sha256:db1015a32173c4553d1ad432bdb48760fdb8ba0782d25ae20349d4aaaf26c28f
+    pullPolicy: IfNotPresent
+    cache: Reuse
+  retention: Delete

--- a/helm/templates/mcp/deployment.yaml
+++ b/helm/templates/mcp/deployment.yaml
@@ -77,6 +77,15 @@ spec:
             {{- end }}
             - name: MCP_BASE_URL
               value: {{ include "srw.mcpUrl" . | quote }}
+          # Tool registration and OIDC discovery can outlast the liveness
+          # window on a cold VM at the default CPU limit. Gate those checks
+          # on successful startup, as for the orchestrator and agents.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health

--- a/src/orchestrator/database/postgres.py
+++ b/src/orchestrator/database/postgres.py
@@ -29032,7 +29032,10 @@ class PostgresDB:
                        j.execution_lane, j.branch_name, j.context, j.created_at,
                        -- The managed repository authority keys on repo_name;
                        -- a row without it dispatches a credential-less remote.
-                       j.repo_name
+                       j.repo_name,
+                       (SELECT execution.harness_adapter FROM srw_execution_specs execution
+                        WHERE execution.work_kind='Job' AND execution.work_id=j.id)
+                       AS execution_harness_adapter
                 FROM jobs j
                 -- These three terms are the partial index idx_jobs_dispatchable
                 -- (0046). Statuses MUST stay literal (see docstring); the
@@ -29122,7 +29125,10 @@ class PostgresDB:
                        j.project_id, j.parent_job_id, j.priority, j.runner_kind,
                        j.execution_lane, j.branch_name, j.context, j.created_at,
                        j.expert_id, j.document_path, j.worktree_path,
-                       j.delegation_context
+                       j.delegation_context,
+                       (SELECT execution.harness_adapter FROM srw_execution_specs execution
+                        WHERE execution.work_kind='Job' AND execution.work_id=j.id)
+                       AS execution_harness_adapter
                 FROM jobs j
                 WHERE j.status IN ('created', 'paused')
                   AND NOT EXISTS (SELECT 1 FROM srw_execution_specs execution WHERE execution.work_kind='Job' AND execution.work_id=j.id AND execution.harness_adapter='generic')

--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -771,6 +771,7 @@ from shared.runtime.core.tool_report import (  # noqa: E402
 from shared.tool_catalog import TOOL_REGISTRY  # noqa: E402
 from orchestrator.services.nats_bridge import nats_bridge  # noqa: E402
 from orchestrator.services.vm_provisioner import vm_provisioner  # noqa: E402
+from orchestrator.services.vm_workspace_config import vm_provisioning_options  # noqa: E402
 from orchestrator.services.vm_readiness import vm_readiness_prober  # noqa: E402
 from orchestrator.services.container_provisioner import (  # noqa: E402
     WORKSPACE_RUNTIME_INCARNATION_KEY,
@@ -7604,16 +7605,15 @@ async def _try_dispatch_pending_jobs() -> None:
                         config_override = job.get("config_override") or {}
                         if isinstance(config_override, str):
                             config_override = json.loads(config_override)
-                        vm_cfg = config_override.get("workspace", {}).get("vm", {})
+                        vm_options = await vm_provisioning_options(
+                            postgres_db, "Job", job, fallback=config_override
+                        )
                         ok = await vm_provisioner.create_vm(
                             job_id=job_id,
                             agent_config=canonical_config_name(
                                 job.get("config_name", "worker_base")
                             ),
-                            vm_image=vm_cfg.get("image"),
-                            cpu_cores=vm_cfg.get("cpu_cores", 8),
-                            memory=vm_cfg.get("memory", "16Gi"),
-                            disk_size=vm_cfg.get("disk_size"),
+                            **vm_options,
                             description=job.get("description", ""),
                         )
                         if ok:
@@ -7678,16 +7678,15 @@ async def _try_dispatch_pending_jobs() -> None:
                         config_override = job.get("config_override") or {}
                         if isinstance(config_override, str):
                             config_override = json.loads(config_override)
-                        vm_cfg = config_override.get("workspace", {}).get("vm", {})
+                        vm_options = await vm_provisioning_options(
+                            postgres_db, "Job", job, fallback=config_override
+                        )
                         await vm_provisioner.create_vm(
                             job_id=job_id,
                             agent_config=canonical_config_name(
                                 job.get("config_name", "worker_base")
                             ),
-                            vm_image=vm_cfg.get("image"),
-                            cpu_cores=vm_cfg.get("cpu_cores", 8),
-                            memory=vm_cfg.get("memory", "16Gi"),
-                            disk_size=vm_cfg.get("disk_size"),
+                            **vm_options,
                             description=job.get("description", ""),
                             fresh=False,
                         )
@@ -7771,16 +7770,15 @@ async def _try_dispatch_pending_jobs() -> None:
                         config_override = job.get("config_override") or {}
                         if isinstance(config_override, str):
                             config_override = json.loads(config_override)
-                        vm_cfg = config_override.get("workspace", {}).get("vm", {})
+                        vm_options = await vm_provisioning_options(
+                            postgres_db, "Job", job, fallback=config_override
+                        )
                         await vm_provisioner.create_vm(
                             job_id=job_id,
                             agent_config=canonical_config_name(
                                 job.get("config_name", "worker_base")
                             ),
-                            vm_image=vm_cfg.get("image"),
-                            cpu_cores=vm_cfg.get("cpu_cores", 8),
-                            memory=vm_cfg.get("memory", "16Gi"),
-                            disk_size=vm_cfg.get("disk_size"),
+                            **vm_options,
                             description=job.get("description", ""),
                             fresh=False,
                         )

--- a/src/orchestrator/services/manifest_execution.py
+++ b/src/orchestrator/services/manifest_execution.py
@@ -121,6 +121,15 @@ class ManifestExecutionService:
             if workspace
             else "none"
         )
+        if adapter == "srw/v1" and backend == "vm":
+            from orchestrator.services.vm_workspace_policy import (
+                VmPermissionDependencies,
+                check_vm_permission,
+            )
+
+            await check_vm_permission(
+                user, job_needs_vm=True, dependencies=VmPermissionDependencies(self.db)
+            )
         if datasource_ids:
             if not self.authorize_datasources:
                 raise HTTPException(503, "Datasource admission is unavailable.")

--- a/src/orchestrator/services/manifest_execution_snapshot.py
+++ b/src/orchestrator/services/manifest_execution_snapshot.py
@@ -385,8 +385,9 @@ async def prepare_srw_snapshot(
             srw_workspace_config,
         )
 
-        expected = srw_workspace_config(workspace_selection["resolved"])["backend"]
-        if blob["agent"]["workspace"]["backend"] != expected:
+        expected = srw_workspace_config(workspace_selection["resolved"])
+        actual = policy.get("workspace") or {}
+        if any(actual.get(key) != value for key, value in expected.items()):
             raise HTTPException(409, "Workspace assignment changed during admission.")
         for key in ("document", "resolved"):
             prepared[key]["spec"]["execution"]["workspace"] = deepcopy(
@@ -565,6 +566,15 @@ async def prepare_srw_session_patch(
         )
 
     if backend_of(old_workspace) == backend_of(new_workspace):
+        _, old_policy = srw_snapshot_config(current)
+        if (policy.get("workspace") or {}).get("vm") != (
+            old_policy.get("workspace") or {}
+        ).get("vm"):
+            raise HTTPException(
+                422,
+                "Session settings cannot change the captured VM image or resources; "
+                "create a new session with the selected workspace.",
+            )
         for key in ("document", "resolved"):
             prepared[key]["spec"]["execution"]["workspace"] = deepcopy(
                 current[key]["spec"]["execution"]["workspace"]

--- a/src/orchestrator/services/manifest_workspace_selection.py
+++ b/src/orchestrator/services/manifest_workspace_selection.py
@@ -1,6 +1,7 @@
 """Workspace selections shared by the existing SRW Job and Session APIs."""
 
 from copy import deepcopy
+import re
 from typing import Any
 
 from fastapi import HTTPException
@@ -18,19 +19,62 @@ def srw_workspace_config(workspace: dict | None) -> dict:
     """Render supported workspace recipes; never silently discard recipe fields."""
     if workspace is None:
         return {"backend": "none"}
+    try:
+        validate_workspace_selection(workspace)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
     recipe = workspace.get("template", {}).get("inline")
     if (
         not isinstance(recipe, dict)
-        or set(recipe) - {"backend", "retention"}
+        or set(recipe) - {"backend", "retention", "resources", "environment"}
         or recipe.get("retention", "Delete") != "Delete"
     ):
         raise HTTPException(
             422,
-            "The SRW workspace provisioner currently supports backend-only templates "
-            "with Delete retention. Prepared/initialized recipes, retained instances "
+            "The SRW workspace provisioner supports backend-only templates and "
+            "prebuilt VM images/resources with Delete retention. Initialized recipes, retained instances "
             "and instanceRef require a supported workspace provisioner.",
         )
-    return execution_workspace_config({"workspace": recipe})
+    result = {"backend": recipe["backend"]}
+    if not set(recipe) & {"resources", "environment"}:
+        return result
+    if recipe["backend"] != "vm":
+        raise HTTPException(
+            422, "SRW template images and resources require backend vm."
+        )
+    environment = recipe.get("environment", {})
+    if (
+        set(environment) - {"image", "pullPolicy", "cache"}
+        or environment.get("pullPolicy", "IfNotPresent") != "IfNotPresent"
+        or environment.get("cache", "Reuse") != "Reuse"
+    ):
+        raise HTTPException(
+            422,
+            "VM templates support prebuilt images with IfNotPresent/Reuse only; "
+            "preparation and other pull/cache policies are not supported.",
+        )
+    vm = {}
+    if "image" in environment:
+        image = environment["image"]
+        # The VM controller embeds this registry reference in its disk manifest.
+        # Accept registry paths/tags/digests, never whitespace or YAML syntax.
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:/@-]*", image) is None:
+            raise HTTPException(422, "VM image must be a registry image reference.")
+        vm["image"] = image
+    resources = recipe.get("resources", {})
+    if "cpu" in resources:
+        cpu = resources["cpu"]
+        if int(cpu) != cpu:
+            raise HTTPException(
+                422, "VM templates require a whole number of CPU cores."
+            )
+        vm["cpu_cores"] = int(cpu)
+    for field, target in (("memory", "memory"), ("storage", "disk_size")):
+        if field in resources:
+            vm[target] = resources[field]
+    if vm:
+        result["vm"] = vm
+    return result
 
 
 async def select_execution_workspace(

--- a/src/orchestrator/services/nats_bridge.py
+++ b/src/orchestrator/services/nats_bridge.py
@@ -292,6 +292,7 @@ class NatsBridge:
         entity_type: str = "job",
         set_provisioning: bool = True,
         provision_generation: str | None = None,
+        disk_size: Optional[str] = None,
     ) -> bool:
         """Publish a VM creation request.
 
@@ -301,6 +302,7 @@ class NatsBridge:
             vm_image: Container disk image (None = controller default).
             cpu_cores: Number of CPU cores.
             memory: Memory allocation (e.g. "4Gi").
+            disk_size: Requested rootdisk size; omitted uses the controller default.
             description: Job description passed to the agent.
             entity_type: "job" (default) or "thread" — controls which DB
                 table receives context updates when the daemon registers.
@@ -348,6 +350,8 @@ class NatsBridge:
             payload["provision_generation"] = generation
         if vm_image:
             payload["vm_image"] = vm_image
+        if disk_size is not None:
+            payload["disk_size"] = disk_size
         payload = sign_payload(
             payload,
             direction="request",

--- a/src/orchestrator/services/thread_admission.py
+++ b/src/orchestrator/services/thread_admission.py
@@ -1052,13 +1052,14 @@ async def commit_thread_creation(
 
 async def _provision_thread_vm(
     tid: str,
-    cpu: int,
-    mem: str,
     cfg: str,
+    config_override: dict,
     *,
     dependencies: ThreadAdmissionDependencies,
 ) -> None:
     """Install the VM provision intent under the thread's current authority."""
+    from orchestrator.services.vm_workspace_config import vm_provisioning_options
+
     store = dependencies.store
     vm_provisioner = dependencies.vm_provisioner
     try:
@@ -1072,11 +1073,16 @@ async def _provision_thread_vm(
             elif current_authority is None:
                 ok = False
             else:
+                options = await vm_provisioning_options(
+                    store,
+                    "Session",
+                    current,
+                    fallback=current_metadata.get("config_override", config_override),
+                )
                 ok = await vm_provisioner.create_thread_vm(
                     thread_id=tid,
                     agent_config=cfg,
-                    cpu_cores=cpu,
-                    memory=mem,
+                    **options,
                     expected_runtime_generation=(current_authority.generation),
                     expected_agent_id=(
                         str(current["agent_id"])
@@ -1158,20 +1164,11 @@ async def provision_thread_workspace(
         # fire-and-forget (mirrors the container task) with the requested
         # sizing; the agent pod provisioned below SSHes into the VM once it
         # reports ready. (knowledge-base/knowledge/features/session_create_on_vm.md)
-        _vm_ws = (config_override.get("workspace") or {}).get("vm") or {}
-        try:
-            _vm_cpu = int(_vm_ws.get("cpu_cores") or 8)
-        except (TypeError, ValueError):
-            _vm_cpu = 8
-        _vm_mem = str(_vm_ws.get("memory") or "16Gi")
-        _vm_agent_config = plan.config_name
-
         asyncio.create_task(
             _provision_thread_vm(
                 thread_id,
-                _vm_cpu,
-                _vm_mem,
-                _vm_agent_config,
+                plan.config_name,
+                config_override,
                 dependencies=dependencies,
             )
         )

--- a/src/orchestrator/services/thread_config_update.py
+++ b/src/orchestrator/services/thread_config_update.py
@@ -61,6 +61,7 @@ from orchestrator.schemas.thread_config import (
 )
 from orchestrator.security.access import redact_config_override
 from orchestrator.services.manifest_runtime_ownership import require_srw_runtime
+from orchestrator.services.vm_workspace_config import vm_provisioning_options
 from orchestrator.services.session_runtime_admission import (
     protected_cloud_marker_state,
     thread_runtime_authority,
@@ -375,8 +376,15 @@ async def agent_upgrade_thread_to_vm(
                 "message": "VM already provisioned or in progress",
             }
 
+        options = await vm_provisioning_options(
+            dependencies.store,
+            "Session",
+            thread,
+            fallback=metadata.get("config_override"),
+        )
         ok = await vm_provisioner.create_thread_vm(
             thread_id=thread_id,
+            **options,
             agent_config=canonical_config_name(
                 thread.get("config_name", "session_base")
             ),

--- a/src/orchestrator/services/vm_provisioner.py
+++ b/src/orchestrator/services/vm_provisioner.py
@@ -726,6 +726,7 @@ class VMProvisioner:
                 entity_type="job",
                 set_provisioning=fresh,
                 provision_generation=generation,
+                **({"disk_size": disk_size} if disk_size is not None else {}),
             )
 
         if self._http_available:
@@ -2210,6 +2211,7 @@ class VMProvisioner:
                 entity_type="thread",
                 set_provisioning=False,
                 provision_generation=generation,
+                **({"disk_size": disk_size} if disk_size is not None else {}),
             )
         elif self._http_available:
             result = await self._create_http(

--- a/src/orchestrator/services/vm_workspace_config.py
+++ b/src/orchestrator/services/vm_workspace_config.py
@@ -1,0 +1,39 @@
+"""Provision VMs from captured execution settings, independently of Experts."""
+
+from copy import deepcopy
+
+from fastapi import HTTPException
+
+from orchestrator.services.manifest_execution_snapshot import (
+    object_value,
+    read_execution,
+    srw_snapshot_config,
+)
+
+
+async def vm_provisioning_options(store, work_kind: str, work: dict, *, fallback=None):
+    """Use the immutable policy for current work; keep historical inputs working.
+
+    The typed harness configuration deliberately excludes VM allocation fields.
+    The captured policy retains execution-owned infrastructure after Expert
+    configuration has been stripped of allocation authority. The adapter marker
+    comes from the database's execution join, never a caller's context.
+    """
+    configuration = fallback
+    if work.get("execution_harness_adapter") is not None:
+        snapshot = await read_execution(store, work_kind, str(work["id"]))
+        if snapshot is None:
+            raise HTTPException(409, "VM execution configuration is unavailable.")
+        _, configuration = srw_snapshot_config(snapshot)
+    workspace = object_value(object_value(configuration).get("workspace"))
+    vm = object_value(workspace.get("vm"))
+    return {
+        target: deepcopy(vm[source])
+        for source, target in (
+            ("image", "vm_image"),
+            ("cpu_cores", "cpu_cores"),
+            ("memory", "memory"),
+            ("disk_size", "disk_size"),
+        )
+        if vm.get(source) is not None
+    }

--- a/src/orchestrator/services/workspace_suspension.py
+++ b/src/orchestrator/services/workspace_suspension.py
@@ -42,6 +42,7 @@ from orchestrator.services.vm_provisioner import (
     vm_persistent_rootdisk_enabled,
 )
 from orchestrator.services.workspace_binding import CANVAS_WORKSPACE_GENERATION_KEY
+from orchestrator.services.vm_workspace_config import vm_provisioning_options
 from orchestrator.services.workspace_lifecycle import WorkspaceOwner
 
 logger = logging.getLogger(__name__)
@@ -2251,8 +2252,15 @@ class WorkspaceSuspensionService:
                 raw_vm = metadata.get("vm")
                 if raw_vm is not None and not isinstance(raw_vm, dict):
                     return False
+                options = await vm_provisioning_options(
+                    self._db,
+                    "Session",
+                    thread,
+                    fallback=metadata.get("config_override"),
+                )
                 ok = await self._vm_provisioner.create_thread_vm(
                     thread_id,
+                    **options,
                     expected_runtime_generation=generation,
                     expected_agent_id=(
                         str(thread["agent_id"])

--- a/tests/test_b06_lane_b_thread_admission.py
+++ b/tests/test_b06_lane_b_thread_admission.py
@@ -812,6 +812,35 @@ class TestCreateThreadOperation:
 
 class TestWorkspaceActuation:
     @pytest.mark.asyncio
+    async def test_vm_create_forwards_the_selected_image_and_rootdisk(self):
+        vm = {
+            "image": "registry.example/dev-vm:v1",
+            "cpu_cores": 12,
+            "memory": "24Gi",
+            "disk_size": "120Gi",
+        }
+        override = {"workspace": {"backend": "vm", "vm": vm}}
+        deps = _deps(
+            vm_provisioner=SimpleNamespace(
+                is_available=True, create_thread_vm=AsyncMock(return_value=True)
+            ),
+            store={
+                "get_thread": AsyncMock(
+                    return_value=_created_thread(metadata={"config_override": override})
+                )
+            },
+        )
+        plan = await _plan(ThreadCreateRequest(config_override=override), deps)
+        await ta.provision_thread_workspace(plan, THREAD, dependencies=deps)
+        await asyncio.sleep(0)
+        called = deps.vm_provisioner.create_thread_vm.await_args.kwargs
+        assert called["vm_image"] == vm["image"]
+        assert called["cpu_cores"] == 12
+        assert called["memory"] == "24Gi"
+        assert called["disk_size"] == "120Gi"
+        assert called["expected_runtime_generation"] == GENERATION
+
+    @pytest.mark.asyncio
     async def test_a_lite_session_provisions_no_workspace_pod(self):
         deps = _deps(
             container_provisioner=SimpleNamespace(

--- a/tests/test_manifest_vm_workspaces.py
+++ b/tests/test_manifest_vm_workspaces.py
@@ -1,0 +1,255 @@
+"""A selected development VM survives template edits and execution recovery."""
+
+from copy import deepcopy
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import HTTPException
+import pytest
+
+from orchestrator.services.manifest_execution_snapshot import (
+    prepare_srw_session_patch,
+    read_execution,
+    srw_snapshot_config,
+)
+from orchestrator.services.manifest_resources import ManifestResourceService
+from orchestrator.services.manifest_store import ManifestStore
+from orchestrator.services.manifest_workspace_selection import (
+    select_execution_workspace,
+    srw_workspace_config,
+)
+from orchestrator.services.vm_workspace_config import vm_provisioning_options
+from shared.manifests import preview_documents
+from tests import test_manifest_native_full_schema as full_schema
+
+actor = full_schema.actor
+database = full_schema.database
+postgres_url = full_schema.postgres_url
+
+IMAGE = "registry.example/dev-vm@sha256:" + "a" * 64
+VM = {"image": IMAGE, "cpu_cores": 12, "memory": "24Gi", "disk_size": "120Gi"}
+OPTIONS = {"vm_image": IMAGE, "cpu_cores": 12, "memory": "24Gi", "disk_size": "120Gi"}
+
+
+def template():
+    return {
+        "apiVersion": "srw/v1alpha1",
+        "kind": "WorkspaceTemplate",
+        "metadata": {"name": "development"},
+        "spec": {
+            "backend": "vm",
+            "resources": {"cpu": 12, "memory": "24Gi", "storage": "120Gi"},
+            "environment": {"image": IMAGE},
+        },
+    }
+
+
+def test_resolved_prebuilt_vm_preserves_allocation_without_changing_the_source():
+    document = template()
+    before = deepcopy(document)
+    resolved = preview_documents(
+        [document], default_scope={"kind": "Catalog", "name": "shared"}
+    )["resolved"][0]
+    assert srw_workspace_config({"template": {"inline": resolved["spec"]}}) == {
+        "backend": "vm",
+        "vm": VM,
+    }
+    assert document == before
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"backend": "sandbox"},
+        {"resources": {"cpu": 1.5}},
+        {"resources": {"cpu": True}},
+        {"environment": {"image": "bad\nmanifest: injected"}},
+        {"environment": {"image": IMAGE, "prepare": []}},
+        {"environment": {"image": IMAGE, "pullPolicy": "Always"}},
+        {"environment": {"image": IMAGE, "pullPolicy": "Never"}},
+        {"environment": {"image": IMAGE, "cache": "Rebuild"}},
+        {"initialize": []},
+        {"retention": "Retain"},
+    ],
+)
+def test_unsupported_vm_recipes_are_refused_instead_of_partially_applied(changes):
+    spec = {**template()["spec"], **changes}
+    with pytest.raises(HTTPException) as denied:
+        srw_workspace_config({"template": {"inline": spec}})
+    assert denied.value.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lane", ["pinned", "stateless"])
+async def test_job_dispatch_keeps_selected_image_and_size_after_template_edit(
+    database, actor, lane
+):
+    service = ManifestResourceService(database)
+    document = template()
+    await service.apply(json.dumps(document), actor, format="json")
+    job = full_schema.assignment(adapter="srw/v1", mode="Reported")
+    job["spec"]["execution"]["workspace"] = {
+        "template": {"ref": {"name": "development"}}
+    }
+    _, _, _, _, work_id, snapshot = await full_schema.admit(database, actor, job)
+    _, policy = srw_snapshot_config(snapshot)
+    assert policy["workspace"]["vm"] == VM
+    await database.execute(
+        "UPDATE jobs SET execution_lane=$2 WHERE id=$1::uuid", work_id, lane
+    )
+    row = await ManifestStore(database).by_name(
+        "WorkspaceTemplate",
+        {"kind": "Account", "name": str(actor["id"])},
+        "development",
+    )
+    document["spec"]["environment"]["image"] = "registry.example/other:v2"
+    document["spec"]["resources"]["cpu"] = 2
+    await service.apply(
+        json.dumps(document),
+        actor,
+        format="json",
+        expected_versions={
+            f"WorkspaceTemplate/Account/{actor['id']}/development": row[
+                "resource_version"
+            ]
+        },
+    )
+    candidates = await (
+        database.get_dispatchable_jobs()
+        if lane == "pinned"
+        else database.get_admittable_stateless_jobs()
+    )
+    candidate = next(row for row in candidates if str(row["id"]) == work_id)
+    assert candidate["execution_harness_adapter"] == "srw/v1"
+    assert (
+        await vm_provisioning_options(
+            database,
+            "Job",
+            candidate,
+            fallback={"workspace": {"vm": {"image": "mutable-projection:v2"}}},
+        )
+        == OPTIONS
+    )
+    assert await read_execution(database, "Job", work_id) == snapshot
+
+
+@pytest.mark.asyncio
+async def test_session_snapshot_keeps_vm_allocation_across_unrelated_patch(
+    database, actor
+):
+    workspace, receipt = await select_execution_workspace(
+        database,
+        actor,
+        role="session",
+        project_id=None,
+        supplied=True,
+        workspace={"template": {"inline": template()["spec"]}},
+    )
+    thread_id = await database.create_thread(
+        user_id=str(actor["id"]),
+        datasource_ids=[],
+        initial_metadata={"config_override": {"workspace": workspace}},
+        workspace_selection=receipt,
+    )
+    current = await read_execution(database, "Session", thread_id)
+    thread = await database.get_thread(thread_id)
+    metadata = json.loads(thread["metadata"])
+    prepared, _ = await prepare_srw_session_patch(
+        database,
+        current,
+        thread,
+        metadata,
+        [],
+        {"llm": {"temperature": 0.2}},
+    )
+    _, policy = srw_snapshot_config(prepared)
+    assert policy["workspace"]["vm"] == VM
+    assert prepared["resolved"]["spec"]["execution"]["workspace"] == receipt["resolved"]
+    assert await vm_provisioning_options(database, "Session", thread) == OPTIONS
+    with pytest.raises(HTTPException) as denied:
+        await prepare_srw_session_patch(
+            database,
+            current,
+            thread,
+            metadata,
+            [],
+            {"workspace": {"vm": {"image": "registry.example/other:v2"}}},
+        )
+    assert denied.value.status_code == 422
+    assert await read_execution(database, "Session", thread_id) == current
+
+
+@pytest.mark.asyncio
+async def test_project_default_selects_vm_and_explicit_none_suppresses_it(
+    database, actor
+):
+    service = ManifestResourceService(database)
+    project = {
+        "apiVersion": "srw/v1alpha1",
+        "kind": "Project",
+        "metadata": {"name": "development-team"},
+        "spec": {
+            "resources": {
+                "workspaces": {"development": {"inline": template()["spec"]}}
+            },
+            "defaults": {"workspace": "development"},
+        },
+    }
+    applied = await service.apply(json.dumps(project), actor, format="json")
+    entry = next(x for x in applied["resources"] if x["resource"]["kind"] == "Project")
+    row = await ManifestStore(database).by_id(entry["uid"])
+    project_id = str(row["linked_id"])
+    selected, receipt = await select_execution_workspace(
+        database,
+        actor,
+        role="worker",
+        project_id=project_id,
+    )
+    assert selected == {"backend": "vm", "vm": VM}
+    assert receipt["project_revision"] == row["revision"]
+    selected, _ = await select_execution_workspace(
+        database,
+        actor,
+        role="worker",
+        project_id=project_id,
+        supplied=True,
+        workspace=None,
+    )
+    assert selected == {"backend": "none"}
+
+
+@pytest.mark.asyncio
+async def test_marked_execution_never_falls_back_when_snapshot_is_missing():
+    db = SimpleNamespace(fetchrow=AsyncMock(return_value=None))
+    with pytest.raises(HTTPException) as denied:
+        await vm_provisioning_options(
+            db,
+            "Job",
+            {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "execution_harness_adapter": "srw/v1",
+            },
+            fallback={"workspace": {"vm": VM}},
+        )
+    assert denied.value.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("admin", [False, True])
+async def test_manifest_vm_admission_obeys_the_existing_operator_gate(
+    database, actor, monkeypatch, admin
+):
+    user = {**actor, "is_admin": admin}
+    monkeypatch.setattr(database, "user_can_use_vm", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        database,
+        "get_system_setting",
+        AsyncMock(return_value={"value": {"enabled": not admin}}),
+    )
+    job = full_schema.assignment(adapter="srw/v1", mode="Reported")
+    job["spec"]["execution"]["workspace"] = {"template": {"inline": template()["spec"]}}
+    with pytest.raises(HTTPException) as denied:
+        await full_schema.admit(database, user, job)
+    assert denied.value.status_code == 403
+    assert await database.fetchval("SELECT count(*) FROM jobs") == 0

--- a/tests/test_nats_bridge.py
+++ b/tests/test_nats_bridge.py
@@ -396,6 +396,32 @@ class TestRequestVmCreate:
     """Tests for NatsBridge.request_vm_create()."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("entity_type", ["job", "thread"])
+    async def test_create_signs_requested_disk_size(
+        self, bridge_with_db, mock_nc, entity_type
+    ):
+        from orchestrator.services.vm_lifecycle_auth import verify_payload
+
+        secret = b"development-vm-test-lifecycle-secret-32-bytes"
+        bridge_with_db._lifecycle_hmac_secret = secret
+        await bridge_with_db.request_vm_create(
+            job_id="test-job",
+            entity_type=entity_type,
+            vm_image="registry.example/dev-vm:v1",
+            disk_size="120Gi",
+            provision_generation=PROVISION_GENERATION,
+        )
+        payload = json.loads(mock_nc.publish.call_args.args[1])
+        assert payload["disk_size"] == "120Gi"
+        assert verify_payload(
+            payload, direction="request", operation="create", secret=secret
+        )
+        payload["disk_size"] = "240Gi"
+        assert not verify_payload(
+            payload, direction="request", operation="create", secret=secret
+        )
+
+    @pytest.mark.asyncio
     async def test_create_publishes_correct_payload(
         self, bridge_with_db, mock_nc, mock_db
     ):

--- a/tests/test_shared_browser_infra.py
+++ b/tests/test_shared_browser_infra.py
@@ -34,10 +34,9 @@ def test_container_and_vm_install_the_same_stream_conformance_program():
 
     dockerfile = (REPO / "docker/Dockerfile.workspace").read_text()
     assert (
-        "COPY docker/check-browser-stream.py /usr/local/bin/check-browser-stream"
+        "COPY --chmod=0755 docker/check-browser-stream.py /usr/local/bin/check-browser-stream"
         in dockerfile
     )
-    assert "chmod +x /usr/local/bin/check-browser-stream" in dockerfile
 
     packer = (REPO / "docker/agent-vm-base/stage2.pkr.hcl").read_text()
     provision = (REPO / "docker/agent-vm-base/scripts/provision-stage2.sh").read_text()

--- a/tests/test_tokenizer_cache.py
+++ b/tests/test_tokenizer_cache.py
@@ -190,8 +190,8 @@ def test_agent_recipes_prepare_final_cache_and_verify_as_nonroot_offline(recipe)
         if line.startswith("COPY ") and script in line
     ]
     assert len(copies) == 1
-    assert copies[0][1] == script
-    target = copies[0][2]
+    assert copies[0][-2] == script
+    target = copies[0][-1]
     preparation = instructions.index(f"RUN python {target} prepare")
     verification = instructions.index(f"RUN --network=none python {target} verify")
     runtime_user = instructions.index("USER srw")

--- a/tests/test_workspace_suspension.py
+++ b/tests/test_workspace_suspension.py
@@ -2374,6 +2374,27 @@ class TestVmRestoreEndsAtTheCreate:
         return thread
 
     @pytest.mark.asyncio
+    async def test_resume_preserves_custom_image_and_resources(self, monkeypatch):
+        monkeypatch.setenv("VM_PERSISTENT_ROOTDISK", "true")
+        svc, vm_prov = make_vm_service()
+        before = self._kept_thread()
+        before["metadata"]["config_override"]["workspace"]["vm"] = {
+            "image": "registry.example/dev-vm:v1",
+            "cpu_cores": 12,
+            "memory": "24Gi",
+            "disk_size": "120Gi",
+        }
+        svc._db.get_thread = AsyncMock(return_value=before)
+        svc._extract_snapshot = AsyncMock()
+        assert await svc.restore_thread_workspace("tid-vm") is True
+        options = vm_prov.create_thread_vm.await_args.kwargs
+        assert options["vm_image"] == "registry.example/dev-vm:v1"
+        assert options["cpu_cores"] == 12
+        assert options["memory"] == "24Gi"
+        assert options["disk_size"] == "120Gi"
+        svc._extract_snapshot.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_kept_disk_restore_succeeds_without_ssh_host(self, monkeypatch):
         monkeypatch.setenv("VM_PERSISTENT_ROOTDISK", "true")
         svc, vm_prov = make_vm_service()


### PR DESCRIPTION
## Description

SRW WorkspaceTemplates could describe a VM image and resources, but SRW admission rejected those fields and Session provisioning dropped the image and disk selection. Prebuilt VM templates now select an image, whole CPU cores, memory and storage independently of the Expert, and preserve that allocation through Job dispatch and Session creation/resume.

Adds a digest-pinned `srw-development-vm.yaml` example using the published VM disk with Docker, k3d, Tilt and the development prerequisites already installed. Named templates and Project defaults resolve into immutable execution settings. Editing a template affects new executions; changing an existing Session's VM image or sizing requires a new Session. Manifest VM admission uses the existing operator permission gate, and both VM lifecycle transports carry disk size.

Image-build helpers now receive explicit permissions when copied into agent/workspace images. A private workspace checkout can have mode-0600 source files; previously that left the root-owned tokenizer helper unreadable by the final non-root image user, stopping a clean Tilt build. The image sets the required read/execute modes while preserving private host checkout permissions and the offline verification gate.

MCP now has a startup probe so its normal liveness checks do not repeatedly terminate initialization under the chart's 200m CPU limit. This was reproduced on the fresh VM; the replacement pod became Ready with zero restarts.

This slice uses the existing golden-disk import/clone mechanism (`IfNotPresent`/`Reuse`, `Delete` retention). Preparation, other pull/cache policies and retained-template provisioning remain explicitly unsupported. The image must implement SRW's VM guest contract.

## Type of change

- [x] New feature
- [x] Documentation update

## How Has This Been Tested?

- [x] Focused manifest, Session, VM lifecycle, permissions and MCP/CLI regression suites: 417 and 303 tests passed with `PYTHONSAFEPATH=1`.
- [x] Real PostgreSQL tests cover both Job dispatch lanes, immutable template resolution, Project defaults, explicit null, Session settings and denied VM admission.
- [x] Ruff lint/format checks, manifest validation and `git diff --check` passed.
- [x] Full Python suite at `be5f8bd668cb1f28f6a8dda6ca06a9fbd1b88e61`: **30,540 passed, 178 skipped**, exit 0, in 17m 14s. Command: `PYTHONSAFEPATH=1 SRW_PYTHON=.venv/bin/python ./scripts/pytest-fast.sh tests/ -q --tb=short` (Python 3.13 locally; CI also exercises its configured Python/runtime targets).
- [x] Image-permission regression: 22 focused tests passed. A real Docker build with mode-0600 source files failed before the fix and passed after it; all five root-owned helpers were readable by a non-root user and none were group/world writable.
- [x] [PR CI at `cc8023c31`](https://github.com/Knaeckebrothero/Superhuman-Remote-Worker/actions/runs/34514158708) passed, including Python tests and agent, orchestrator and workspace image builds.
- [x] Fresh SRW/MCP-created VM using the pinned disk and 12 CPU / 24Gi / 120Gi: preinstalled tools worked without adding host packages; all six source images built and uploaded; final `tilt ci` exited **0**, Helm reported **deployed**, and **all 16 pods were Ready**. The final MCP pod had zero restarts.
- [x] Normal Chromium/Keycloak/BFF login and HTTPS health returned **200** with certificate verification enabled after per-user development CA setup. Native template apply/readback preserved the exact image and resource spec; stored Job preview returned **200**, with no Job created or execution admitted.
- [x] Both required Helm lint profiles, rendered probe checks and CI's eight chart profiles passed for the startup fix. [Final CI at `f61978be4`](https://github.com/Knaeckebrothero/Superhuman-Remote-Worker/actions/runs/34521909959) passed, including its full Python run and changed image builds. Policy and database-migration workflows are also green.

The live run required supervisor intervention after the two cold-start defects, slow registry PUTs that completed after the client timed out, and initial service startup timeouts. It verifies the VM and application runtime; it does not establish unattended worker recovery or a single-pass cold build. The validation worker also wrote three test-artifact files to an unrelated repository inherited from its default Project; those additions were reverted and the exact pre-test tree restored. Future validation must use an explicit isolated Project and only the intended repository Connectors. No nested LLM job was run. The outer Job used the existing VM override on the current dev deployment; the new manifest adapter was exercised in the nested stack and has not yet been deployed to main dev.

## Checklist

- [x] Self-reviewed and follows existing architecture/style.
- [x] Public configuration documentation and example updated.
- [x] Regression tests exercise persisted allocation and lifecycle forwarding.
- [x] Full-suite results recorded.
- [x] Fresh-VM acceptance evidence and supervising review preserved in the Job repository. Nested k3d cluster and registry removed; validation Job reviewed and completed; its VM and private rootdisk released through the existing fenced lifecycle. The shared golden disk cache remains available.
