### PR TITLE
fix(orchestrator): verify pinned SSH host key for thread upload SFTP

### DIFF
--- a/policy/runtime_coordinate_callers.txt
+++ b/policy/runtime_coordinate_callers.txt
@@ -98,7 +98,7 @@ src/orchestrator/services/ssh_helpers.py  stream_extract_snapshot  ssh  build_ag
 src/orchestrator/services/ssh_helpers.py  wait_for_agent_ssh  remote-effect  create_owned_subprocess_exec  48e3950913b3  #1  pinned-host-key
 src/orchestrator/services/ssh_helpers.py  wait_for_agent_ssh  ssh  build_agent_ssh_cmd  03995d101f31  #1  pinned-host-key
 src/orchestrator/services/thread_cloud_diff.py  _reset_thread_overlay  http  client.post  92db99489add  #1  exact-runtime-recipient
-src/orchestrator/services/thread_uploads.py  resolve_thread_upload_destination  ssh  _SshTarget  edfd95d5f2d1  #1  pinned-host-key
+src/orchestrator/services/thread_uploads.py  resolve_thread_upload_destination  ssh  _SshTarget  4b9010b50487  #1  pinned-host-key
 src/orchestrator/services/thread_workspace_delivery.py  agent_get_thread_workspace_locked  remote-effect  remote_canvas_presentation_available  f40229a0ebf2  #1  fresh-k8s-attestation
 src/orchestrator/services/thread_workspace_delivery.py  agent_get_thread_workspace_locked  remote-effect  remote_canvas_presentation_available  f40229a0ebf2  #2  fresh-k8s-attestation
 src/orchestrator/services/vm_provisioner.py  VMProvisioner.release_vm_captured  remote-effect  self._snapshot_service.capture_vm_snapshot  22b821d81a7c  #1  vm-authority

--- a/src/orchestrator/services/thread_uploads.py
+++ b/src/orchestrator/services/thread_uploads.py
@@ -41,6 +41,7 @@ landed. That path's whole security burden sits in ``_safe_upload_relpath``.
 from __future__ import annotations
 
 import asyncio
+import base64
 import io
 import logging
 import mimetypes
@@ -72,6 +73,7 @@ from orchestrator.services.canvas_ssh import (
     PinnedSFTPPool,
     asyncssh,
 )
+from orchestrator.services.ssh_helpers import _fingerprint_host_key
 from orchestrator.services.stateless_workspace_gate import (
     stateless_session_workspace_check,
 )
@@ -140,6 +142,11 @@ class _SshTarget:
     username: str
     key_path: str
     workspace_path: str
+    # The control-plane-attested SSH host key this endpoint must present. It has
+    # no default on purpose: a caller that cannot name the key it expects has no
+    # way to tell the workspace apart from anything else answering on that
+    # address, and must be refused rather than silently trusting the peer.
+    host_key_fingerprint: str
 
 
 @dataclass
@@ -177,6 +184,112 @@ class ThreadUploadError(Exception):
         super().__init__(detail)
         self.status_code = status_code
         self.detail = detail
+
+
+class _HostKeyMismatch(Exception):
+    """The peer's SSH host key is not the attested one. Never caught as I/O."""
+
+
+if paramiko is not None:
+
+    class _PinnedHostKeyPolicy(paramiko.MissingHostKeyPolicy):
+        """Accept exactly the control-plane-attested host key, nothing else.
+
+        Paramiko consults this hook once the key exchange has produced the
+        server's host key but *before* it authenticates, so raising here means
+        the workspace private key is never offered to a peer that failed to
+        prove its identity. The digest covers the whole key blob, including its
+        type, so matching an ed25519 pin is itself proof the peer presented the
+        attested ed25519 key.
+        """
+
+        def __init__(self, expected_fingerprint: str):
+            self._expected = expected_fingerprint
+
+        def missing_host_key(self, client, hostname, key) -> None:
+            presented = _fingerprint_host_key(
+                base64.b64encode(key.asbytes()).decode("ascii")
+            )
+            if not secrets.compare_digest(presented, self._expected):
+                raise _HostKeyMismatch(
+                    f"host key for {hostname} does not match the attested key"
+                )
+
+
+def _pinned_ssh_client(target: _SshTarget) -> Any:
+    """Build an SSHClient that will only complete against ``target``'s key."""
+
+    if paramiko is None:  # pragma: no cover - import guard
+        raise ThreadUploadError(
+            status_code=503, detail="paramiko is not installed on the orchestrator"
+        )
+    if not _valid_ssh_fingerprint(target.host_key_fingerprint):
+        # No usable pin means the peer's identity cannot be established at all.
+        # Trusting it anyway is precisely the man-in-the-middle exposure this
+        # refusal exists to close, so there is no fallback policy here.
+        logger.warning(
+            "Refusing SFTP to %s:%d — no attested SSH host key fingerprint",
+            target.host,
+            target.port,
+        )
+        raise ThreadUploadError(
+            status_code=409,
+            detail="Workspace SSH host key attestation is unavailable",
+        )
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(
+        _PinnedHostKeyPolicy(target.host_key_fingerprint)
+    )
+    return client
+
+
+def _connect_pinned_sftp(client: Any, target: _SshTarget) -> None:
+    """Connect ``client`` to ``target``, enforcing its pinned host key."""
+
+    try:
+        client.connect(
+            hostname=target.host,
+            port=target.port,
+            username=target.username,
+            key_filename=target.key_path,
+            timeout=15,
+            banner_timeout=15,
+            auth_timeout=15,
+            allow_agent=False,
+            look_for_keys=False,
+        )
+    except _HostKeyMismatch as e:
+        # An identity verdict, not a reachability one: the host answered and
+        # presented the wrong key. Reporting it as "could not reach" would hide
+        # an active man-in-the-middle behind a retryable-looking message.
+        logger.error(
+            "SSH host key mismatch for %s@%s:%d — refusing SFTP",
+            target.username,
+            target.host,
+            target.port,
+        )
+        client.close()
+        raise ThreadUploadError(
+            status_code=502,
+            detail=(
+                f"Workspace SSH host key verification failed "
+                f"({target.host}:{target.port})"
+            ),
+        ) from e
+    except Exception as e:
+        logger.warning(
+            "SSH connect failed for %s@%s:%d (%s)",
+            target.username,
+            target.host,
+            target.port,
+            e,
+        )
+        client.close()
+        raise ThreadUploadError(
+            status_code=502,
+            detail=f"Could not reach workspace ({target.host}:{target.port})",
+        ) from e
 
 
 def _sanitize_filename(filename: str) -> str:
@@ -734,19 +847,28 @@ def resolve_thread_upload_destination(
 
     vm_ctx = metadata.get("vm") or {}
     ws_ctx = metadata.get("workspace_container") or {}
+    binding = metadata.get("_workspace_binding") or {}
 
     host: str | None = None
     port = 22
     workspace_path = DEFAULT_WORKSPACE_PATH
+    host_key_fingerprint = ""
 
     if backend == "vm" and vm_ctx.get("status") == "ready":
         host = vm_ctx.get("ssh_host") or vm_ctx.get("pod_ip")
         port = int(vm_ctx.get("ssh_port") or 22)
         workspace_path = vm_ctx.get("workspace_path") or DEFAULT_WORKSPACE_PATH
+        host_key_fingerprint = vm_ctx.get("ssh_host_key_fingerprint") or ""
     elif backend in {None, "sandbox"} and ws_ctx.get("status") == "ready":
         host = ws_ctx.get("host") or ws_ctx.get("pod_ip")
         port = int(ws_ctx.get("port") or 22)
         workspace_path = ws_ctx.get("workspace_path") or DEFAULT_WORKSPACE_PATH
+        host_key_fingerprint = ws_ctx.get("ssh_host_key_fingerprint") or ""
+
+    # The binding is the control plane's own record of which key this workspace
+    # was provisioned with, so it wins over whatever the endpoint context echoes.
+    if isinstance(binding, dict) and binding.get("ssh_host_key_fingerprint"):
+        host_key_fingerprint = str(binding["ssh_host_key_fingerprint"])
 
     if not host:
         # Genuinely transient now: this branch is only reachable for tiers that
@@ -769,6 +891,7 @@ def resolve_thread_upload_destination(
         username=DEFAULT_USERNAME,
         key_path=key_path,
         workspace_path=workspace_path,
+        host_key_fingerprint=host_key_fingerprint,
     )
 
 
@@ -1129,37 +1252,8 @@ def _sftp_write_files(
     ``_expand_payloads_for_extraction``; a corrupt/unsafe zip falls back to
     being written verbatim like any other file.
     """
-    if paramiko is None:  # pragma: no cover - import guard
-        raise ThreadUploadError(
-            status_code=503, detail="paramiko is not installed on the orchestrator"
-        )
-
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    try:
-        client.connect(
-            hostname=target.host,
-            port=target.port,
-            username=target.username,
-            key_filename=target.key_path,
-            timeout=15,
-            banner_timeout=15,
-            auth_timeout=15,
-            allow_agent=False,
-            look_for_keys=False,
-        )
-    except Exception as e:
-        logger.warning(
-            "SSH connect failed for %s@%s:%d (%s)",
-            target.username,
-            target.host,
-            target.port,
-            e,
-        )
-        raise ThreadUploadError(
-            status_code=502,
-            detail=f"Could not reach workspace ({target.host}:{target.port})",
-        ) from e
+    client = _pinned_ssh_client(target)
+    _connect_pinned_sftp(client, target)
 
     try:
         sftp = client.open_sftp()
@@ -1843,37 +1937,8 @@ def _sftp_delete_file(target: _SshTarget, relpath: str) -> bool:
     Returns:
         True when something was removed, False when there was nothing there.
     """
-    if paramiko is None:  # pragma: no cover - import guard
-        raise ThreadUploadError(
-            status_code=503, detail="paramiko is not installed on the orchestrator"
-        )
-
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    try:
-        client.connect(
-            hostname=target.host,
-            port=target.port,
-            username=target.username,
-            key_filename=target.key_path,
-            timeout=15,
-            banner_timeout=15,
-            auth_timeout=15,
-            allow_agent=False,
-            look_for_keys=False,
-        )
-    except Exception as e:
-        logger.warning(
-            "SSH connect failed for %s@%s:%d (%s)",
-            target.username,
-            target.host,
-            target.port,
-            e,
-        )
-        raise ThreadUploadError(
-            status_code=502,
-            detail=f"Could not reach workspace ({target.host}:{target.port})",
-        ) from e
+    client = _pinned_ssh_client(target)
+    _connect_pinned_sftp(client, target)
 
     try:
         sftp = client.open_sftp()

--- a/tests/test_b04_lane_w_thread_files.py
+++ b/tests/test_b04_lane_w_thread_files.py
@@ -728,6 +728,7 @@ class TestPreparePinnedVmThreadOperation:
             username="agent-host",
             key_path="/k",
             workspace_path="/w",
+            host_key_fingerprint="SHA256:" + "a" * 43,
         )
         lease = SimpleNamespace(
             identity=SimpleNamespace(ssh_host="10.0.0.1", ssh_port=2222),
@@ -777,7 +778,12 @@ class TestPreparePinnedVmThreadOperation:
                 THREAD,
                 {"execution_lane": "pinned"},
                 _SshTarget(
-                    host="h", port=1, username="u", key_path="/k", workspace_path="/w"
+                    host="h",
+                    port=1,
+                    username="u",
+                    key_path="/k",
+                    workspace_path="/w",
+                    host_key_fingerprint="SHA256:" + "a" * 43,
                 ),
                 operation_kind="thread_upload",
                 store=SimpleNamespace(),
@@ -853,6 +859,7 @@ class TestPreparePinnedK8sThreadUpload:
             username="agent-host",
             key_path="/k",
             workspace_path="/w",
+            host_key_fingerprint="SHA256:" + "a" * 43,
         )
         monkeypatch.setattr(
             "orchestrator.services.thread_uploads."
@@ -887,6 +894,7 @@ class TestPreparePinnedK8sThreadUpload:
             username="agent-host",
             key_path="/k",
             workspace_path="/w",
+            host_key_fingerprint="SHA256:" + "a" * 43,
         )
         thread = self._thread()
         monkeypatch.setattr(

--- a/tests/test_thread_uploads.py
+++ b/tests/test_thread_uploads.py
@@ -13,6 +13,8 @@ virtual backend's own contract tests use — so nothing here needs rclone or SSH
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
 import io
 import posixpath
 import stat
@@ -1193,6 +1195,93 @@ def _patch_sshclient(monkeypatch, fake_sftp) -> None:
     monkeypatch.setattr(paramiko, "SSHClient", MagicMock(return_value=mock_ssh))
 
 
+# =============================================================================
+# Host-key pinning (CodeQL py/paramiko-missing-host-key-validation, #463/#464)
+#
+# The MagicMock above cannot see host-key verification at all: it swallows
+# set_missing_host_key_policy() and never calls the policy back, so a client
+# that accepts ANY key passes it just as happily as one that checks. These
+# doubles reproduce the part of paramiko's connect() that matters here — the
+# policy is consulted for an unknown host key BEFORE credentials are offered —
+# so "rejected" can be asserted as "raised, and never authenticated".
+# =============================================================================
+
+HOST_KEY_BLOB = b"\x00\x00\x00\x0bssh-ed25519 fake-host-key-blob"
+OTHER_KEY_BLOB = b"\x00\x00\x00\x0bssh-ed25519 attacker-key-blob"
+
+
+def _fingerprint_of(blob: bytes) -> str:
+    """The OpenSSH SHA256 form ``ssh_helpers._fingerprint_host_key`` produces."""
+    digest = hashlib.sha256(blob).digest()
+    return "SHA256:" + base64.b64encode(digest).decode("ascii").rstrip("=")
+
+
+class _FakeHostKey:
+    """paramiko ``PKey`` stand-in: the wire blob its fingerprint is taken over."""
+
+    def __init__(self, blob: bytes):
+        self._blob = blob
+
+    def get_name(self) -> str:
+        return "ssh-ed25519"
+
+    def asbytes(self) -> bytes:
+        return self._blob
+
+
+class _PolicyRecordingSSHClient:
+    """Minimal ``paramiko.SSHClient`` that exercises the host-key policy.
+
+    ``connect()`` consults the installed policy exactly where paramiko does —
+    after key exchange, before authentication — so a policy that raises stops
+    the connection with no credentials sent. ``authenticated`` records whether
+    we got that far.
+    """
+
+    def __init__(self, sftp, host_key_blob: bytes):
+        self._sftp = sftp
+        self._host_key = _FakeHostKey(host_key_blob)
+        self.policy = None
+        self.authenticated = False
+        self.closed = False
+
+    def set_missing_host_key_policy(self, policy) -> None:
+        self.policy = policy
+
+    def connect(self, hostname, port=22, **kwargs):
+        if self.policy is None:
+            raise AssertionError(
+                "connect() ran without a host-key policy — an unknown host key "
+                "would have been trusted implicitly"
+            )
+        self.policy.missing_host_key(self, hostname, self._host_key)
+        # Only reached when the policy accepted the key.
+        self.authenticated = True
+
+    def open_sftp(self):
+        if not self.authenticated:
+            raise AssertionError("open_sftp() before the host key was accepted")
+        return self._sftp
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_pinned_sshclient(monkeypatch, fake_sftp, host_key_blob: bytes):
+    """Install the recording client and hand back the instance connect() used."""
+    import paramiko
+
+    created = []
+
+    def _factory():
+        client = _PolicyRecordingSSHClient(fake_sftp, host_key_blob)
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(paramiko, "SSHClient", _factory)
+    return created
+
+
 @pytest.fixture
 def sftp_env(monkeypatch):
     """Patch paramiko.SSHClient so _sftp_write_files runs against a fake
@@ -1210,13 +1299,18 @@ def modeless_sftp_env(monkeypatch):
     return fake_sftp
 
 
-def _ssh_target() -> _SshTarget:
+def _ssh_target(host_key_fingerprint: str | None = None) -> _SshTarget:
     return _SshTarget(
         host="10.0.0.5",
         port=22,
         username="agent-host",
         key_path="/key",
         workspace_path="/home/agent-host/workspace",
+        host_key_fingerprint=(
+            _fingerprint_of(HOST_KEY_BLOB)
+            if host_key_fingerprint is None
+            else host_key_fingerprint
+        ),
     )
 
 
@@ -1478,6 +1572,96 @@ class TestSftpDelete:
             _sftp_delete_file(_ssh_target(), "report.pdf")
 
         assert err.value.status_code == 502
+
+
+# =============================================================================
+# Host-key verification (CodeQL #463 / #464)
+#
+# Both SFTP helpers used to install ``paramiko.AutoAddPolicy()``, which trusts
+# whatever key the peer presents — the orchestrator-to-workspace hop had no
+# defence against a man-in-the-middle even though the pinned fingerprint was
+# already verified upstream. These tests pin the behaviour that replaced it.
+# =============================================================================
+
+
+class TestSftpHostKeyVerification:
+    UPLOADS_DIR = "/home/agent-host/workspace/uploads"
+    PAYLOAD = [("notes.md", b"hello", "text/markdown")]
+
+    def test_the_matching_host_key_is_accepted(self, monkeypatch):
+        """The legitimate workspace presents exactly the pinned key."""
+        fake_sftp = _FakeSftp()
+        created = _patch_pinned_sshclient(monkeypatch, fake_sftp, HOST_KEY_BLOB)
+
+        result = _sftp_write_files(
+            _ssh_target(host_key_fingerprint=_fingerprint_of(HOST_KEY_BLOB)),
+            self.PAYLOAD,
+        )
+
+        assert result[0].path == "uploads/notes.md"
+        assert fake_sftp.files[f"{self.UPLOADS_DIR}/notes.md"] == b"hello"
+        assert created[0].authenticated is True
+
+    def test_a_mismatched_host_key_is_refused_before_authenticating(self, monkeypatch):
+        """The man-in-the-middle case: a different key on the expected host.
+
+        The refusal has to land before authentication, or the workspace
+        private key has already been offered to the impostor.
+        """
+        fake_sftp = _FakeSftp()
+        created = _patch_pinned_sshclient(monkeypatch, fake_sftp, OTHER_KEY_BLOB)
+
+        with pytest.raises(ThreadUploadError) as err:
+            _sftp_write_files(
+                _ssh_target(host_key_fingerprint=_fingerprint_of(HOST_KEY_BLOB)),
+                self.PAYLOAD,
+            )
+
+        assert err.value.status_code == 502
+        assert created[0].authenticated is False
+        assert fake_sftp.files == {}
+
+    def test_a_mismatched_host_key_is_refused_on_delete_too(self, monkeypatch):
+        fake_sftp = _FakeSftp()
+        fake_sftp.dirs.add(self.UPLOADS_DIR)
+        fake_sftp.files[f"{self.UPLOADS_DIR}/report.pdf"] = b"bytes"
+        created = _patch_pinned_sshclient(monkeypatch, fake_sftp, OTHER_KEY_BLOB)
+
+        with pytest.raises(ThreadUploadError):
+            _sftp_delete_file(
+                _ssh_target(host_key_fingerprint=_fingerprint_of(HOST_KEY_BLOB)),
+                "report.pdf",
+            )
+
+        assert created[0].authenticated is False
+        assert fake_sftp.files[f"{self.UPLOADS_DIR}/report.pdf"] == b"bytes"
+
+    @pytest.mark.parametrize("fingerprint", ["", "   ", "not-a-fingerprint"])
+    def test_an_unusable_pin_refuses_to_connect_at_all(self, monkeypatch, fingerprint):
+        """No pin means no verification is possible, so there is nothing to
+        fall back to — AutoAddPolicy would be exactly the hole being closed."""
+        fake_sftp = _FakeSftp()
+        created = _patch_pinned_sshclient(monkeypatch, fake_sftp, HOST_KEY_BLOB)
+
+        with pytest.raises(ThreadUploadError):
+            _sftp_write_files(
+                _ssh_target(host_key_fingerprint=fingerprint), self.PAYLOAD
+            )
+
+        assert created == []  # refused before a connection was even opened
+        assert fake_sftp.files == {}
+
+    def test_a_missing_pin_refuses_the_delete_path_too(self, monkeypatch):
+        fake_sftp = _FakeSftp()
+        fake_sftp.dirs.add(self.UPLOADS_DIR)
+        fake_sftp.files[f"{self.UPLOADS_DIR}/report.pdf"] = b"bytes"
+        created = _patch_pinned_sshclient(monkeypatch, fake_sftp, HOST_KEY_BLOB)
+
+        with pytest.raises(ThreadUploadError):
+            _sftp_delete_file(_ssh_target(host_key_fingerprint=""), "report.pdf")
+
+        assert created == []
+        assert fake_sftp.files[f"{self.UPLOADS_DIR}/report.pdf"] == b"bytes"
 
 
 # =============================================================================

--- a/tests/test_thread_uploads_stateless.py
+++ b/tests/test_thread_uploads_stateless.py
@@ -605,6 +605,7 @@ async def test_pinned_legacy_upload_shape_is_unchanged(monkeypatch):
         username="agent-host",
         key_path="/ssh/key",
         workspace_path="/home/agent-host/workspace",
+        host_key_fingerprint="SHA256:" + "a" * 43,
     )
     called: dict = {}
 


### PR DESCRIPTION
Closes CodeQL alerts **#463** and **#464** (`py/paramiko-missing-host-key-validation`) in
`src/orchestrator/services/thread_uploads.py`.

## The problem

Both SFTP helpers built a `paramiko.SSHClient()` and installed
`set_missing_host_key_policy(paramiko.AutoAddPolicy())`:

- `_sftp_write_files` (alert #463)
- `_sftp_delete_file` (alert #464)

`AutoAddPolicy` accepts whatever host key the peer presents, so the
orchestrator-to-workspace SFTP hop had no protection against a man-in-the-middle. Worse,
paramiko offers the client's private key *after* the host-key policy runs — so an impostor
answering on the workspace address was handed the workspace SSH credentials before any
bytes moved.

**This is not a false positive.** The pinned fingerprint was already known and verified
elsewhere in the same module — `_StatelessUploadAuthority.host_key_fingerprint`,
`_resolve_stateless_upload_authority` comparing `expected_host_key_fingerprint` against the
workspace binding — it simply never reached the paramiko layer, and `_SshTarget` had no
field to carry it.

## The change

- **`_SshTarget.host_key_fingerprint: str`** — a new field with **no default**, so every
  caller must supply it. A defaulted empty value would let a caller silently skip the pin,
  which is the exact class of bug being fixed.
- **`_PinnedHostKeyPolicy(paramiko.MissingHostKeyPolicy)`** — verifies the presented key and
  **raises** on mismatch. Paramiko consults this hook after key exchange but *before*
  authentication, so a mismatch aborts the connection with no credentials sent. This is
  asserted by a test, not assumed.
- **`_pinned_ssh_client()` / `_connect_pinned_sftp()`** — one shared factory now used by both
  helpers, so the two call sites cannot drift apart. The pin is validated with the module's
  existing `_valid_ssh_fingerprint()` *before* connecting; an absent or malformed
  fingerprint is refused outright. There is no fallback policy.
- **`resolve_thread_upload_destination()`** populates the fingerprint, with the
  `_workspace_binding` record (the control plane's own record of how the workspace was
  provisioned) taking precedence over the endpoint context.

### Reuse, not reinvention

The fingerprint is computed by the **existing** `ssh_helpers._fingerprint_host_key()`, fed
`base64.b64encode(key.asbytes())`, and compared with `secrets.compare_digest` — the same
`SHA256:<base64>` form used by `_scan_pinned_host_key` and `ide_settings.py`. No second
fingerprint format was introduced.

`_scan_pinned_host_key` itself was deliberately *not* reused: it is async and shells out to
`ssh-keyscan`, while both SFTP helpers are synchronous (offloaded via
`joined_blocking_call`), and a scan-then-connect sequence leaves a key-swap window that the
in-band policy check does not.

### Failure taxonomy

A host-key mismatch raises through a dedicated `_HostKeyMismatch` that is caught *before* the
pre-existing broad `except Exception`, so an identity failure reports
`Workspace SSH host key verification failed` rather than being masked as the retryable-looking
`Could not reach workspace`. A missing pin is a 409; a mismatch is a 502.

### Sweep

The whole module was swept for other client sites: `AutoAddPolicy` now appears **0** times, and
there is exactly one `paramiko.SSHClient()` construction (the shared pinned factory). No CodeQL
suppression, no dependency change, no TLS/SSH verification disabled anywhere.

## Verification

**Tests — `211 passed`** (baseline `204 passed` + 7 new). The baseline had no pre-existing
failures, so the comparison is sound.

New tests in `tests/test_thread_uploads.py::TestSftpHostKeyVerification` cover the three
required cases on **both** the write and delete paths:

| Case | Assertion |
|---|---|
| Correct key | Upload succeeds and the bytes land |
| Wrong key | `ThreadUploadError`, `authenticated is False`, nothing written |
| Missing/malformed pin | `ThreadUploadError`, **no client is constructed at all** |

The existing `_patch_sshclient` MagicMock could not observe any of this — it swallows
`set_missing_host_key_policy` and never calls the policy back, so a client that accepts any
key passed it just as happily as one that checks. The new `_PolicyRecordingSSHClient` double
reproduces paramiko's real ordering and asserts if `connect()` is ever reached without a
policy installed.

**Lint —** `ruff format` reports `4 files left unchanged` and `ruff check src/ tests/` reports
`All checks passed!`, using the CI-pinned `ruff==0.14.10` (`.github/workflows/develop.yml:128`).

**Live verification —** completed against a local k3d/Tilt stack built from this branch; the
full evidence (exact commands, observed responses, orchestrator log lines) is in the
**Live verification** section below.

Only four files are touched: the service module and its three direct test callers, updated
because the new required dataclass field reaches them.

---

## Live verification

Run on a nested k3d stack built **from this branch** (`tilt ci`, cold Docker cache, ~22 min),
so the code exercised is the code in this PR — not a published image. No live LLM keys were
used; no inference was run.

```
$ DOCKER_BUILDKIT=1 BUILDKIT_MAX_PARALLELISM=3 tilt ci --timeout 0
SUCCESS. All workloads are healthy.

$ kubectl --context k3d-srw -n srw get pods -o jsonpath='…{.spec.containers[*].image}…'
srw-orchestrator-…  <- srw-registry:5000/srw-orchestrator:tilt-f16954b0d29c2043
srw-agent-stateless-… <- srw-registry:5000/srw-agent:tilt-a7617aff74b80a14
…                                        # 0 images matching ghcr.io/…:latest
```

### 1. Real session, real upload through the HTTP endpoint

```
$ curl -sk -X POST -H "Authorization: Bearer $ID_TOKEN" -H "Content-Type: application/json" \
    -d '{"title":"PR122 live verification","config_override":{"workspace":{"backend":"sandbox"}}}' \
    https://api.localhost/api/persistent/threads
HTTP=200  {"thread_id":"93d57776-dbc7-465c-8299-de1cc9d05d2e","status":"created"}

$ curl -sk -X POST -H "Authorization: Bearer $ID_TOKEN" -F "files=@srw-pr122-live.txt" \
    https://api.localhost/api/persistent/threads/93d57776-…/uploads
HTTP=200
{"thread_id":"93d57776-…","files":[{"name":"srw-pr122-live.txt","size":108,
  "mime_type":"text/plain","path":"uploads/srw-pr122-live.txt"}]}

$ kubectl --context k3d-srw -n srw exec ws-thread-93d57776-dbc -- \
    cat /home/agent-host/workspace/uploads/srw-pr122-live.txt
PR122 live verification
marker: SRW-PR122-LIVE-MARKER-7f3a91c4
thread: 93d57776-dbc7-465c-8299-de1cc9d05d2e
```

The file landed, byte-identical (108 bytes requested, 108 on disk).

**Which branch served it — stated plainly:** the sandbox session k3d creates is admitted to the
**stateless** pool (`execution_lane: stateless`, `provisioner: k8s`), so per
`routers/thread_files.py:152` this request took the **attested asyncssh** branch, *not* the
paramiko `_sftp_write_files` changed here:

```
INFO orchestrator.services.thread_admission: Thread 93d57776-…: admitted to stateless session pool
INFO asyncssh: Opening SSH connection to ws-thread-93d57776-dbc.srw.svc.cluster.local, port 30022
INFO orchestrator.services.thread_uploads: Uploaded srw-pr122-live.txt (108 bytes) to attested runtime e87ccd8b-…
INFO orchestrator.main: POST /api/persistent/threads/93d57776-…/uploads 200 (175ms)
```

Over that whole request window: `grep -c AutoAddPolicy` → **0**.

### 2. The patched paramiko path itself, against the real workspace sshd

Because the HTTP route above dispatches elsewhere, the changed code was driven directly —
**inside the running orchestrator pod, against the real workspace pod's `sshd`**, over a real
TCP connection and real key exchange. Nothing mocked. The pin was derived **independently** of
the code under test, with `ssh-keygen` against the server's own key file:

```
$ kubectl … exec ws-thread-93d57776-dbc -- cat /etc/ssh/ssh_host_ed25519_key.pub
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9g1wa8hC0H3Um2UYFt8t7eqQtq7cv/LMUKi+wg0OdW
$ ssh-keygen -lf ws_hostkey.pub
256 SHA256:61HNGsoG43FRA7xem4uaef6GIkg5h6Vi5ohkx8HX5NM (ED25519)

$ kubectl … exec srw-orchestrator-… -c orchestrator -- python /tmp/paramiko_live_probe.py \
    ws-thread-93d57776-dbc.srw.svc.cluster.local 30022 SHA256:61HNGsoG43…5NM
```

Verbatim output:

```
paramiko version : 5.0.0
module file      : /app/src/orchestrator/services/thread_uploads.py

=== A. client/policy shape (no connection yet) ===
client type      : paramiko.client.SSHClient
policy type      : orchestrator.services.thread_uploads._PinnedHostKeyPolicy
is AutoAddPolicy : False
is _PinnedHostKeyPolicy: True

=== B. POSITIVE: attested fingerprint -> real SFTP write ===
RESULT: OK -> [UploadedFile(name='pr122-paramiko-positive.txt', size=31, …, path='uploads/pr122-paramiko-positive.txt')]

=== C. NEGATIVE: mutated fingerprint -> must be refused ===
mutated fp       : SHA256:A1HNGsoG43FRA7xem4uaef6GIkg5h6Vi5ohkx8HX5NM
RESULT: refused with ThreadUploadError
  status_code: 502
  detail     : Workspace SSH host key verification failed (ws-thread-93d57776-dbc…:30022)
  __cause__  : _HostKeyMismatch

=== D. missing pin (empty fingerprint) -> refused before connecting ===
RESULT: refused -> 409 | Workspace SSH host key attestation is unavailable

=== VERDICT ===
FAILURES: none
PROBE_RESULT: PASS
SSH host key mismatch for agent-host@ws-thread-93d57776-dbc…:30022 — refusing SFTP
Refusing SFTP to ws-thread-93d57776-dbc…:30022 — no attested SSH host key fingerprint
```

The final two lines are this module's own `logger.error`/`logger.warning` calls — the
orchestrator log shows **host-key verification, never `AutoAddPolicy`**.

Filesystem agrees with the verdict:

```
$ kubectl … exec ws-thread-93d57776-dbc -- ls -la /home/agent-host/workspace/uploads/
-rw-rw-r-- 1 agent-host agent-host  31 pr122-paramiko-positive.txt      # good pin  -> landed
-rw-rw-r-- 1 agent-host agent-host 108 srw-pr122-live.txt
# pr122-paramiko-negative.txt -> ABSENT: the bad-pin write left nothing on the server
```

The mismatch is refused at the host-key hook, *before* authentication, so the workspace private
key is never offered to an unverified peer — the property this PR exists to guarantee, now
observed end-to-end rather than only asserted by a double.

### 3. Focused suite and hygiene, re-run on this branch

```
$ python -m pytest tests/test_thread_uploads.py tests/test_thread_uploads_stateless.py \
    tests/test_b04_lane_w_thread_files.py -q
211 passed in 1.28s

$ ruff check <4 changed files>   # ruff==0.14.10, the CI pin
All checks passed!
$ ruff format --check <4 changed files>
4 files already formatted

$ grep -rn AutoAddPolicy src/orchestrator/services/thread_uploads.py
(no match)
$ python scripts/check_runtime_coordinate_callers.py --check
OK: 104 runtime-coordinate sites classified
```

The negative case is additionally covered by fake-transport unit tests —
`tests/test_thread_uploads.py::TestSftpHostKeyVerification` (7 ids, covering **both** the write
and the delete path).

**No code or test change was needed:** this verification found no defect, so the branch head is
still `a0228bc9` and nothing was pushed.

<details>
<summary>Two local-environment issues hit on the way (no repository change)</summary>

Both are k3d-local setup facts, unrelated to this PR's code:

1. `admin-cli` is the only realm client with direct grants enabled, but it had **no default
   client scopes**, so its tokens carried no `realm_access` claim. `security/auth.py:300-306`
   therefore saw no `admin`/`user` role and the API answered `403 Account pending approval`.
   Fixed in the throwaway realm by attaching the stock `roles`/`profile`/`email` scopes.
2. Session creation needs a ready model catalog (`503 system_not_ready`). Satisfied with a
   dummy endpoint provider and catalog rows — no real key, no inference.

</details>
