### PR TITLE
fix(security): stop leaking exception text and reflected input in HTTP responses

### DIFF
--- a/src/agent/api/app.py
+++ b/src/agent/api/app.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from uuid import uuid4
+
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 
 from agent.api.models import (
@@ -1023,9 +1025,14 @@ def create_app(config_path: Optional[str] = None) -> FastAPI:
                 )
 
             return {"tabs": tabs}
-        except Exception as e:
-            logger.error(f"Failed to get shell state: {e}")
-            return {"tabs": [], "message": f"Error: {str(e)}"}
+        except Exception:
+            error_ref = uuid4().hex[:12]
+            logger.exception("Failed to get shell state (error_ref=%s)", error_ref)
+            return {
+                "tabs": [],
+                "message": "Error: shell state unavailable",
+                "error_ref": error_ref,
+            }
 
     # =========================================================================
     # Orchestrator Integration Endpoints

--- a/src/agent/api/dual_app.py
+++ b/src/agent/api/dual_app.py
@@ -21,7 +21,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse
@@ -1374,8 +1374,14 @@ def create_dual_app(config_path: Optional[str] = None) -> FastAPI:
                     }
                 )
             return {"tabs": tabs}
-        except Exception as e:
-            return {"tabs": [], "message": f"Error: {str(e)}"}
+        except Exception:
+            error_ref = uuid4().hex[:12]
+            logger.exception("Failed to get shell state (error_ref=%s)", error_ref)
+            return {
+                "tabs": [],
+                "message": "Error: shell state unavailable",
+                "error_ref": error_ref,
+            }
 
     # ===================================================================
     # Worker routes (job dispatch)
@@ -2110,9 +2116,13 @@ def create_dual_app(config_path: Optional[str] = None) -> FastAPI:
                     "thread_id": thread_id,
                 }
             )
-        except Exception as e:
-            logger.exception("Failed to detach session")
-            return JSONResponse({"error": str(e)}, status_code=500)
+        except Exception:
+            error_ref = uuid4().hex[:12]
+            logger.exception("Failed to detach session (error_ref=%s)", error_ref)
+            return JSONResponse(
+                {"error": "session detach failed", "error_ref": error_ref},
+                status_code=500,
+            )
 
     # --- Persistent-session REST endpoints (orchestrator-driven turns) ---
     #

--- a/src/agent/api/persistent_app.py
+++ b/src/agent/api/persistent_app.py
@@ -6275,9 +6275,17 @@ def create_persistent_app(config_path: str, thread_id: Optional[str] = None) -> 
                     "sessions_served": _sessions_served,
                 }
             )
-        except Exception as e:
-            logger.exception(f"Failed to detach session for thread {thread_id}")
-            return JSONResponse({"error": str(e)}, status_code=500)
+        except Exception:
+            error_ref = uuid4().hex[:12]
+            logger.exception(
+                "Failed to detach session for thread %s (error_ref=%s)",
+                thread_id,
+                error_ref,
+            )
+            return JSONResponse(
+                {"error": "session detach failed", "error_ref": error_ref},
+                status_code=500,
+            )
 
     @app.post("/cloud-overlay/reset")
     async def cloud_overlay_reset(request: Request):
@@ -6330,18 +6338,35 @@ def create_persistent_app(config_path: str, thread_id: Optional[str] = None) -> 
         try:
             await asyncio.to_thread(_session.reset_cloud_overlay)
             return JSONResponse({"ok": True})
-        except CloudOverlayUnavailable as e:
+        except CloudOverlayUnavailable:
             # Precondition only (overlay exists but isn't active — mount
             # failed, or already torn down): 404 = give up, don't retry.
-            return JSONResponse({"error": str(e)}, status_code=404)
-        except Exception as e:
+            error_ref = uuid4().hex[:12]
+            logger.exception(
+                "Cloud overlay unavailable for thread %s (error_ref=%s)",
+                _thread_id,
+                error_ref,
+            )
+            return JSONResponse(
+                {"error": "cloud overlay unavailable", "error_ref": error_ref},
+                status_code=404,
+            )
+        except Exception:
             # EVERYTHING else is a real failure and must surface as 500
             # (retry/alert). This includes OverlayMountError (remount/wipe
             # script) and RcloneMountError (vfs/refresh) — both subclass
             # RuntimeError, so no RuntimeError-shaped clause may sit above
             # this one or real failures get misreported as 404 give-up.
-            logger.exception("Failed to reset cloud overlay for thread %s", _thread_id)
-            return JSONResponse({"error": str(e)}, status_code=500)
+            error_ref = uuid4().hex[:12]
+            logger.exception(
+                "Failed to reset cloud overlay for thread %s (error_ref=%s)",
+                _thread_id,
+                error_ref,
+            )
+            return JSONResponse(
+                {"error": "cloud overlay reset failed", "error_ref": error_ref},
+                status_code=500,
+            )
 
     # --- Headless REST input endpoints (phase 2) ---
     #

--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -7,6 +7,7 @@ Run with:
 import asyncio
 import copy
 import hashlib
+import html
 import json
 import logging
 import math
@@ -35901,12 +35902,12 @@ def _magic_link_confirmation_page(
     'extended' on success, 'cap_reached' when extend_count >= cap,
     'not_awaiting' when the thread is no longer in awaiting_user.
     """
-    safe_args = (
-        tool_args_preview.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-    )
-    safe_tool = tool_name.replace("&", "&amp;").replace("<", "&lt;")
+    # Both values come from the agent's pending tool call and land in element
+    # content; the token below lands in an attribute. html.escape(quote=True)
+    # covers & < > " ' in one pass — the hand-rolled chains here missed ">" on
+    # the tool name and the quotes on both, which is the reflected-XSS hole.
+    safe_args = html.escape(tool_args_preview, quote=True)
+    safe_tool = html.escape(tool_name, quote=True)
     if intended_decision == "approved":
         button_label = "Confirm: Approve"
         button_color = _BRAND["success"]
@@ -35917,7 +35918,11 @@ def _magic_link_confirmation_page(
         button_label = "Confirm decision"
         button_color = _BRAND["accent-color"]
 
-    quoted_token = urllib.parse.quote(token, safe="")
+    # The token lands in a form ``action`` attribute. Percent-encoding already
+    # removes every character that could close the attribute; escaping the
+    # result as well is a no-op on that output but keeps the sanitizer
+    # explicit at the sink rather than inferred from the encoder.
+    quoted_token = html.escape(urllib.parse.quote(token, safe=""), quote=True)
 
     # Extend banner copy — friendly, action-specific.
     extend_banner_html = ""

--- a/src/orchestrator/services/datasources.py
+++ b/src/orchestrator/services/datasources.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import asyncpg
 from fastapi import HTTPException, Request
@@ -79,6 +80,8 @@ from shared.credential_connectors import (
 from shared.runtime.utils.ssh_key import (
     generate_ed25519_keypair as _generate_ed25519_keypair,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Authenticate the caller. Bound by the router to ``require_approved_user``.
 ApproveCaller = Callable[[], Awaitable[dict[str, Any]]]
@@ -1270,6 +1273,23 @@ async def test_repository_datasource(
     }
 
 
+def _probe_failure(message: str, ds_type: str) -> dict[str, Any]:
+    """Report a failed connectivity probe without disclosing the exception.
+
+    A driver's exception text routinely carries the connection URL (with its
+    password), internal hostnames and ports, so it is logged rather than
+    returned. ``error_ref`` — the same 12-hex-char shape the request-id
+    middleware uses — is what an operator quotes to find that log line.
+    """
+    error_ref = uuid4().hex[:12]
+    logger.exception(
+        "Connectivity probe failed for a %s connector (error_ref=%s)",
+        ds_type,
+        error_ref,
+    )
+    return {"status": "error", "message": message, "error_ref": error_ref}
+
+
 async def test_datasource(
     *,
     resolve_datasource: ResolveDatasourceOwner,
@@ -1296,8 +1316,8 @@ async def test_datasource(
 
             try:
                 return await _test_kb(ds)
-            except Exception as e:
-                return {"status": "error", "message": str(e)[-2000:]}
+            except Exception:
+                return _probe_failure("Knowledge base probe failed", ds_type)
 
         if ds_type == "mcp":
             if not dependencies.mcp_datasources_enabled():
@@ -1314,8 +1334,8 @@ async def test_datasource(
                 version = await conn.fetchval("SELECT version()")
                 await conn.close()
                 return {"status": "ok", "message": f"Connected: {version[:80]}"}
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
+            except Exception:
+                return _probe_failure("PostgreSQL connection failed", ds_type)
 
         elif ds_type == "neo4j":
             try:
@@ -1327,8 +1347,8 @@ async def test_datasource(
                 driver.verify_connectivity()
                 driver.close()
                 return {"status": "ok", "message": "Connected to Neo4j"}
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
+            except Exception:
+                return _probe_failure("Neo4j connection failed", ds_type)
 
         elif ds_type == "mongodb":
             try:
@@ -1338,8 +1358,8 @@ async def test_datasource(
                 client.server_info()
                 client.close()
                 return {"status": "ok", "message": "Connected to MongoDB"}
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
+            except Exception:
+                return _probe_failure("MongoDB connection failed", ds_type)
 
         elif ds_type == "webdav":
             try:
@@ -1354,8 +1374,8 @@ async def test_datasource(
                 )
                 client.list("/")
                 return {"status": "ok", "message": "Connected to WebDAV"}
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
+            except Exception:
+                return _probe_failure("WebDAV connection failed", ds_type)
 
         elif ds_type == "email":
             # Blocking imaplib/smtplib probe runs off the event loop (the
@@ -1372,8 +1392,8 @@ async def test_datasource(
                     "status": "error",
                     "message": "IMAP/SMTP connectivity test timed out after 10s",
                 }
-            except Exception as e:
-                return {"status": "error", "message": str(e)}
+            except Exception:
+                return _probe_failure("IMAP/SMTP connection failed", ds_type)
 
         elif ds_type == "repository":
             return await test_repository_datasource(ds, url, creds)
@@ -1396,4 +1416,9 @@ async def test_datasource(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        error_ref = uuid4().hex[:12]
+        logger.exception("Connector test failed (error_ref=%s)", error_ref)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Connector test failed (error_ref={error_ref})",
+        ) from e

--- a/src/orchestrator/services/job_diff_review.py
+++ b/src/orchestrator/services/job_diff_review.py
@@ -30,6 +30,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
+from uuid import uuid4
 
 from fastapi import HTTPException
 
@@ -268,9 +269,18 @@ async def accept_job_diff(
     try:
         backend = dependencies.cloud_router.for_project(project)
     except Exception as e:
+        error_ref = uuid4().hex[:12]
+        logger.exception(
+            "Mode A: job %s — cloud backend %r unavailable (error_ref=%s)",
+            job_id,
+            backend_id,
+            error_ref,
+        )
         raise HTTPException(
             status_code=503,
-            detail=f"Cloud backend '{backend_id}' unavailable: {e}",
+            detail=(
+                f"Cloud backend '{backend_id}' unavailable (error_ref={error_ref})"
+            ),
         ) from e
     if not backend.is_initialized:
         raise HTTPException(status_code=503, detail="Cloud backend not initialized.")

--- a/src/orchestrator/services/main_cloud_settings.py
+++ b/src/orchestrator/services/main_cloud_settings.py
@@ -33,6 +33,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Optional
+from uuid import uuid4
 
 from fastapi import HTTPException
 
@@ -416,14 +417,35 @@ async def test_main_cloud_settings(
 
     try:
         probe_backend = build_backend(db_overlay=probe_overlay)
-    except Exception as e:
-        return {"ok": False, "detail": f"build_backend failed: {e}"}
+    except Exception:
+        error_ref = uuid4().hex[:12]
+        logger.exception(
+            "Main-cloud dry run: build_backend failed for backend %r (error_ref=%s)",
+            backend_id,
+            error_ref,
+        )
+        return {
+            "ok": False,
+            "detail": "build_backend failed",
+            "error_ref": error_ref,
+        }
 
     try:
         try:
             ok = await probe_backend.ensure_initialized()
-        except Exception as e:
-            return {"ok": False, "detail": f"ensure_initialized raised: {e}"}
+        except Exception:
+            error_ref = uuid4().hex[:12]
+            logger.exception(
+                "Main-cloud dry run: ensure_initialized raised for backend %r "
+                "(error_ref=%s)",
+                backend_id,
+                error_ref,
+            )
+            return {
+                "ok": False,
+                "detail": "ensure_initialized raised",
+                "error_ref": error_ref,
+            }
         if not ok:
             return {
                 "ok": False,

--- a/tests/test_b04_lane_c_job_diff.py
+++ b/tests/test_b04_lane_c_job_diff.py
@@ -12,6 +12,7 @@ relied on.
 
 from __future__ import annotations
 
+import re
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -505,8 +506,12 @@ class TestAcceptJobDiffGates:
             await accept_job_diff(_request(), JOB_ID, dependencies=deps)
 
         assert exc.value.status_code == 503
-        assert exc.value.detail == (
-            "Cloud backend 'nextcloud' unavailable: no such instance"
+        # The router's exception text is logged, not returned; the client gets
+        # the backend name it needs plus the id that finds the log line.
+        assert "no such instance" not in exc.value.detail
+        assert re.fullmatch(
+            r"Cloud backend 'nextcloud' unavailable \(error_ref=[0-9a-f]{12}\)",
+            exc.value.detail,
         )
         assert control.order == ["guard:mode_a_accept"]
 

--- a/tests/test_b04_lane_m_main_cloud_settings_routes.py
+++ b/tests/test_b04_lane_m_main_cloud_settings_routes.py
@@ -20,6 +20,7 @@ secret env var is wired.
 from __future__ import annotations
 
 import json
+import re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -568,7 +569,13 @@ def test_dry_run_reports_a_build_failure_without_persisting(monkeypatch):
 
     body = wired.client.post(f"{BASE}/test", json=_valid_put_body()).json()
 
-    assert body == {"ok": False, "detail": "build_backend failed: bad url"}
+    # The builder's exception text can name internal hosts and credentials, so
+    # the client gets the route's own wording plus the correlation id that
+    # finds the logged exception.
+    assert body["ok"] is False
+    assert body["detail"] == "build_backend failed"
+    assert "bad url" not in json.dumps(body)
+    assert re.fullmatch(r"[0-9a-f]{12}", body["error_ref"])
     wired.store.delete_system_setting.assert_not_awaited()
 
 

--- a/tests/test_codeql_error_disclosure.py
+++ b/tests/test_codeql_error_disclosure.py
@@ -1,0 +1,668 @@
+"""No HTTP response carries exception text, a traceback, or unescaped input.
+
+CodeQL reported 16 ``py/stack-trace-exposure`` and 2 ``py/reflective-xss``
+findings against these handlers. Both classes are pinned here, over the real
+HTTP transport, because the leak is a property of the *response body* and only
+a client-side view proves it is gone.
+
+Each error-path case monkeypatches the collaborator the handler calls so it
+raises, then asserts three things at once: the status code the handler already
+used is unchanged, the body carries neither the exception's message nor a
+``Traceback``, and an ``error_ref`` joins the response to the server-side log
+line that does hold the full exception.
+
+The reflected-XSS cases drive the two magic-link routes with a live
+``<script>`` payload in the token path segment and in the tool metadata, and
+assert the response escapes it rather than echoing markup.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import urllib.parse
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests._mounted_router import mount_main_routes, mount_router
+
+
+# The text of the exceptions raised below. No response body may contain it.
+BOOM = "postgres://user:hunter2@db.internal/secret rejected at 10.1.2.3:5432"
+XSS = "<script>alert(1)</script>"
+# The token arrives as a single path segment, and ASGI unquotes ``%2F`` before
+# routing — a payload containing "/" would 404 on the split path instead of
+# reaching the handler. This slash-free payload reflects into the same sink
+# (the form ``action`` attribute) and breaks out of it just as effectively.
+XSS_PATH = '"><img src=x onerror=alert(1)>'
+
+USER_ID = "00000000-0000-0000-0000-0000000000c1"
+USER = {"id": USER_ID, "is_admin": False}
+PROJECT_ID = "00000000-0000-0000-0000-0000000000b1"
+DATASOURCE_ID = "00000000-0000-0000-0000-0000000000d1"
+JOB_ID = "a6fa6f2a-9101-4c1e-9b9e-0000000000c1"
+AGENT_ID = "11111111-1111-4111-8111-111111111111"
+PROCESS_GENERATION = "33333333-3333-4333-8333-333333333333"
+
+
+def assert_no_leak(payload: object) -> None:
+    """The serialized response may not disclose internals."""
+    body = str(payload)
+    assert BOOM not in body
+    assert "hunter2" not in body
+    assert "Traceback" not in body
+    assert "RuntimeError" not in body
+    assert "OSError" not in body
+
+
+def error_ref_of(payload: dict) -> str:
+    """Every sanitized error body carries a correlation id for the log line."""
+    ref = payload.get("error_ref")
+    assert isinstance(ref, str) and len(ref) == 12, payload
+    return ref
+
+
+# =============================================================================
+# POST /api/datasources/{datasource_id}/test — six probe branches, all 200
+# =============================================================================
+
+
+def _datasource_wire(row: dict):
+    from orchestrator.routers.datasources import DatasourcesDependencies as RouteDeps
+    from orchestrator.routers.datasources import router
+    from orchestrator.services.datasources import DatasourceDependencies as OpDeps
+    from orchestrator.services.kb_task_registry import KbDatasourceTaskRegistry
+    from orchestrator.services.knowledge_index import KnowledgeIndexDependencies
+
+    store = SimpleNamespace(get_datasource=AsyncMock(return_value=dict(row)))
+
+    async def approved(_request, _store):
+        return USER
+
+    async def datasource_owner(_request, _store, _datasource_id):
+        return USER, dict(row)
+
+    async def project_gate(_request, _store, project_id, **_kw):
+        return USER, {"id": project_id}
+
+    async def job_access(_request, _store, job_id):
+        return USER, {"id": job_id}
+
+    ops = OpDeps(
+        store=store,
+        vector_db=MagicMock(),
+        knowledge_index=KnowledgeIndexDependencies(
+            store=store,
+            vector_db=MagicMock(),
+            gitea_client=MagicMock(),
+            logger=MagicMock(),
+            tasks=KbDatasourceTaskRegistry(),
+            inject_system_kb_embedding_profile=AsyncMock(return_value=None),
+        ),
+        mcp_datasources_enabled=lambda: False,
+        validate_mcp_datasource=lambda _url, _creds: None,
+    )
+    deps = RouteDeps(
+        store=store,
+        operations=ops,
+        require_approved_user=approved,
+        require_project_member=project_gate,
+        require_project_owner=project_gate,
+        require_datasource_access=datasource_owner,
+        require_datasource_owner=datasource_owner,
+        require_job_access=job_access,
+    )
+    app = mount_router(
+        router, factories={"datasources_dependencies_factory": lambda: deps}
+    )
+    return TestClient(app)
+
+
+def _row(ds_type: str) -> dict:
+    return {
+        "id": DATASOURCE_ID,
+        "name": "prod-db",
+        "type": ds_type,
+        "created_by": USER_ID,
+        "credentials": {"username": "dbuser", "password": "hunter2"},
+        "connection_url": "postgresql://dbuser:hunter2@db.internal:5432/app",
+    }
+
+
+def _exploding_module(attribute: str) -> MagicMock:
+    """A stand-in driver module whose first live call raises ``BOOM``."""
+    module = MagicMock()
+    target = module
+    parts = attribute.split(".")
+    for part in parts[:-1]:
+        target = getattr(target, part)
+    getattr(target, parts[-1]).side_effect = RuntimeError(BOOM)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("ds_type", "target", "patcher"),
+    [
+        ("kb", "orchestrator.services.kb_datasources.test_kb_datasource", "attr"),
+        ("postgresql", "orchestrator.services.datasources.asyncpg.connect", "attr"),
+        ("neo4j", "neo4j", "module"),
+        ("mongodb", "pymongo", "module"),
+        ("webdav", "webdav3.client", "module"),
+        ("email", "orchestrator.services.datasources.probe_email_connection", "attr"),
+    ],
+)
+def test_a_failing_connector_probe_reports_without_the_exception_text(
+    ds_type, target, patcher
+):
+    """Each probe branch keeps its 200 ``status: error`` report, minus the leak."""
+    client = _datasource_wire(_row(ds_type))
+
+    if patcher == "attr":
+        context = patch(target, side_effect=RuntimeError(BOOM))
+    else:
+        attribute = {
+            "neo4j": "GraphDatabase.driver",
+            "pymongo": "MongoClient",
+            "webdav3.client": "Client",
+        }[target]
+        context = patch.dict(
+            sys.modules, {target: _exploding_module(attribute)}, clear=False
+        )
+
+    with context:
+        response = client.post(f"/api/datasources/{DATASOURCE_ID}/test")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "error"
+    assert_no_leak(body)
+    error_ref_of(body)
+
+
+def test_a_crashing_probe_gate_is_a_500_without_the_exception_text():
+    """The catch-all re-raise at the end of ``test_datasource``."""
+
+    async def exploding_gate(*_args, **_kwargs):
+        raise RuntimeError(BOOM)
+
+    client = _datasource_wire(_row("postgresql"))
+    client.app.state.datasources_dependencies_factory().require_datasource_owner  # noqa: B018
+    from orchestrator.routers.datasources import DatasourcesDependencies as RouteDeps
+
+    deps = client.app.state.datasources_dependencies_factory()
+    patched = RouteDeps(
+        store=deps.store,
+        operations=deps.operations,
+        require_approved_user=deps.require_approved_user,
+        require_project_member=deps.require_project_member,
+        require_project_owner=deps.require_project_owner,
+        require_datasource_access=exploding_gate,
+        require_datasource_owner=exploding_gate,
+        require_job_access=deps.require_job_access,
+    )
+    client.app.state.datasources_dependencies_factory = lambda: patched
+
+    response = client.post(f"/api/datasources/{DATASOURCE_ID}/test")
+
+    assert response.status_code == 500
+    assert_no_leak(response.json())
+
+
+# =============================================================================
+# POST /api/admin/system-settings/main_cloud/test — two probe failures, 200
+# =============================================================================
+
+MAIN_CLOUD = "/api/admin/system-settings/main_cloud"
+
+
+def _main_cloud_client(monkeypatch, *, build=None, ensure=None):
+    from orchestrator.routers import main_cloud_settings as route_module
+    from orchestrator.services import main_cloud_settings as ops
+    from orchestrator.services.cloud import config as cloud_config
+
+    monkeypatch.setattr(cloud_config, "missing_secret_envs", lambda *_a, **_k: [])
+    if build is not None:
+        monkeypatch.setattr(ops, "build_backend", build)
+    else:
+        probe = SimpleNamespace(
+            ensure_initialized=ensure,
+            health_check=AsyncMock(),
+            close=AsyncMock(),
+        )
+        monkeypatch.setattr(ops, "build_backend", lambda **_k: probe)
+
+    async def require_admin(_request):
+        return {"id": "admin-1"}
+
+    operations = ops.MainCloudSettingsDependencies(
+        store=SimpleNamespace(delete_system_setting=AsyncMock(return_value=None)),
+        cloud_router=SimpleNamespace(active=None, active_instance_id=None),
+        rebind_cloud_router=lambda _backend: None,
+        thread_mount_dependencies=lambda: None,
+    )
+    dependencies = route_module.MainCloudSettingsRouteDependencies(
+        operations=operations,
+        require_admin=require_admin,
+    )
+    app = mount_router(
+        route_module.router,
+        factories={"main_cloud_settings_dependencies_factory": lambda: dependencies},
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _main_cloud_body() -> dict:
+    return {
+        "value": {"backend_id": "opencloud", "base_url": "https://cloud.example"},
+        "credentials_ref": "env:OC_CLIENT_SECRET",
+        "expected_activation_revision": 0,
+    }
+
+
+def test_a_failing_backend_build_keeps_its_reason_without_the_exception_text(
+    monkeypatch,
+):
+    def build(**_kwargs):
+        raise RuntimeError(BOOM)
+
+    client = _main_cloud_client(monkeypatch, build=build)
+
+    response = client.post(f"{MAIN_CLOUD}/test", json=_main_cloud_body())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert body["detail"] == "build_backend failed"
+    assert_no_leak(body)
+    error_ref_of(body)
+
+
+def test_a_failing_backend_init_keeps_its_reason_without_the_exception_text(
+    monkeypatch,
+):
+    client = _main_cloud_client(
+        monkeypatch, ensure=AsyncMock(side_effect=RuntimeError(BOOM))
+    )
+
+    response = client.post(f"{MAIN_CLOUD}/test", json=_main_cloud_body())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert body["detail"] == "ensure_initialized raised"
+    assert_no_leak(body)
+    error_ref_of(body)
+
+
+# =============================================================================
+# POST /api/jobs/{job_id}/{accept,reject} — an unroutable cloud backend, 503
+# =============================================================================
+
+
+def _job_diff_client():
+    from orchestrator.routers.job_diff import JobDiffDependencies, router
+    from orchestrator.services import job_diff_review
+
+    job = {
+        "id": JOB_ID,
+        "status": "pending_review",
+        "project_id": PROJECT_ID,
+        "diff_status": "pending",
+        "cloud_diff_baseline_commit": "a" * 40,
+        "repo_name": "job-a6fa6f2a",
+        "execution_lane": "pinned",
+        "context": {},
+    }
+    project = {
+        "id": PROJECT_ID,
+        "main_cloud_backend": "nextcloud",
+        "main_cloud_folder_handle": "opaque-handle",
+    }
+
+    def unroutable(_project):
+        raise RuntimeError(BOOM)
+
+    store = SimpleNamespace(
+        get_project=AsyncMock(return_value=project),
+        update_job_cloud_diff=AsyncMock(),
+        update_job_merge_status=AsyncMock(),
+        update_job_status=AsyncMock(),
+        merge_job_context=AsyncMock(),
+    )
+    operations = job_diff_review.JobDiffReviewDependencies(
+        store=store,
+        vector_store=SimpleNamespace(name="vector"),
+        forge=SimpleNamespace(is_initialized=True, name="forge"),
+        cloud_router=SimpleNamespace(for_project=unroutable),
+        get_completion_control=MagicMock(),
+        guard_completion_control=AsyncMock(),
+        claim_completion_control=AsyncMock(return_value=None),
+        abort_completion_control_claim=AsyncMock(),
+        advance_project_loop=AsyncMock(),
+    )
+    deps = JobDiffDependencies(
+        store=SimpleNamespace(name="auth-store"),
+        diff_review=operations,
+        require_job_access=AsyncMock(return_value=(USER, job)),
+    )
+    app = mount_router(
+        router, factories={"job_diff_dependencies_factory": lambda: deps}
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_an_unroutable_cloud_backend_names_the_backend_but_not_the_exception():
+    """``accept`` is the only arm that routes to a cloud backend.
+
+    ``reject`` reaches the same module without ever calling
+    ``cloud_router.for_project``; its own ``str(exc)`` at
+    ``job_diff_review.py:554`` is the self-composed
+    ``CompletionControlClaimConflict`` vocabulary the cockpit branches on, so
+    that one stays.
+    """
+    client = _job_diff_client()
+
+    response = client.post(f"/api/jobs/{JOB_ID}/accept")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert "Cloud backend 'nextcloud' unavailable" in detail
+    assert_no_leak(response.json())
+    # ``HTTPException.detail`` is a bare string here, so the correlation id
+    # travels inside it rather than as a sibling key.
+    assert re.search(r"\(error_ref=[0-9a-f]{12}\)", detail), detail
+
+
+# =============================================================================
+# Agent API — persistent_app, dual_app, app
+# =============================================================================
+
+
+def _persistent_client(monkeypatch, *, session, terminate=None):
+    from agent.api import persistent_app as module
+
+    app = module.create_persistent_app("config", "thread-1")
+    monkeypatch.setattr(module, "_stateless_mode", lambda: False)
+    monkeypatch.setattr(module, "_session", session)
+    monkeypatch.setattr(module, "_thread_id", "thread-1")
+    monkeypatch.setattr(module, "_sessions_served", 1)
+    monkeypatch.setattr(
+        module, "_canonical_pinned_session_identity_fingerprint", lambda _v: "fp"
+    )
+    monkeypatch.setattr(
+        module, "_current_pinned_session_identity_fingerprint", lambda: "fp"
+    )
+    monkeypatch.setattr(module, "_registered_pinned_agent_id", lambda: AGENT_ID)
+    monkeypatch.setattr(module, "_session_runtime_generation", "gen-1")
+    monkeypatch.setattr(module, "_session_runtime_attach_token", "tok-1")
+    if terminate is not None:
+        monkeypatch.setattr(module, "_terminate_session", terminate)
+    return TestClient(app, raise_server_exceptions=False), module
+
+
+def _reset_headers() -> dict[str, str]:
+    return {
+        "X-Agent-ID": AGENT_ID,
+        "X-Session-Runtime-Generation": "gen-1",
+        "X-Session-Runtime-Attach-Token": "tok-1",
+    }
+
+
+def _reset_body() -> dict[str, str]:
+    return {
+        "thread_id": "thread-1",
+        "workspace_generation": "wsgen-1",
+        "workspace_runtime_incarnation": "inc-1",
+    }
+
+
+def _overlay_session(reset_error: Exception) -> SimpleNamespace:
+    def reset_cloud_overlay():
+        raise reset_error
+
+    return SimpleNamespace(
+        overlay_mount_manager=MagicMock(),
+        protected_cloud_required=True,
+        protected_workspace_generation="wsgen-1",
+        protected_workspace_runtime_incarnation="inc-1",
+        reset_cloud_overlay=reset_cloud_overlay,
+    )
+
+
+def test_persistent_detach_failure_is_a_500_without_the_exception_text(monkeypatch):
+    client, _ = _persistent_client(
+        monkeypatch,
+        session=MagicMock(),
+        terminate=AsyncMock(side_effect=RuntimeError(BOOM)),
+    )
+
+    response = client.post(
+        "/session/detach", json={"session_identity_fingerprint": "fp"}
+    )
+
+    assert response.status_code == 500
+    assert_no_leak(response.json())
+    error_ref_of(response.json())
+
+
+def test_an_unavailable_cloud_overlay_stays_a_404_without_the_exception_text(
+    monkeypatch,
+):
+    from agent.api.persistent_session import CloudOverlayUnavailable
+
+    client, _ = _persistent_client(
+        monkeypatch, session=_overlay_session(CloudOverlayUnavailable(BOOM))
+    )
+
+    response = client.post(
+        "/cloud-overlay/reset", json=_reset_body(), headers=_reset_headers()
+    )
+
+    assert response.status_code == 404
+    assert_no_leak(response.json())
+    error_ref_of(response.json())
+
+
+def test_a_failing_cloud_overlay_reset_stays_a_500_without_the_exception_text(
+    monkeypatch,
+):
+    client, _ = _persistent_client(
+        monkeypatch, session=_overlay_session(RuntimeError(BOOM))
+    )
+
+    response = client.post(
+        "/cloud-overlay/reset", json=_reset_body(), headers=_reset_headers()
+    )
+
+    assert response.status_code == 500
+    assert_no_leak(response.json())
+    error_ref_of(response.json())
+
+
+def _shell_state_client(monkeypatch, module_name: str):
+    if module_name == "app":
+        from agent.api import app as module
+
+        app = module.create_app()
+    else:
+        from agent.api import dual_app as module
+
+        app = module.create_dual_app()
+
+    shell = MagicMock()
+    shell.list_tabs.side_effect = RuntimeError(BOOM)
+    agent = MagicMock()
+    agent._shell_manager = shell
+    monkeypatch.setattr(module, "_agent", agent)
+    monkeypatch.setattr(module, "_current_job_id", JOB_ID)
+    monkeypatch.setattr(
+        module,
+        "_orchestrator_client",
+        SimpleNamespace(
+            agent_id=AGENT_ID, dispatch_process_generation=PROCESS_GENERATION
+        ),
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("module_name", ["app", "dual_app"])
+def test_a_failing_shell_state_read_stays_a_200_without_the_exception_text(
+    monkeypatch, module_name
+):
+    client = _shell_state_client(monkeypatch, module_name)
+
+    response = client.post(
+        "/system/shell-state",
+        json={
+            "expected_agent_id": AGENT_ID,
+            "expected_pod_uid": None,
+            "expected_process_generation": PROCESS_GENERATION,
+            "expected_job_id": JOB_ID,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tabs"] == []
+    assert_no_leak(body)
+    error_ref_of(body)
+
+
+def test_dual_app_detach_failure_is_a_500_without_the_exception_text(monkeypatch):
+    from agent.api import dual_app as module
+    from agent.api import persistent_app as pa
+
+    app = module.create_dual_app()
+    monkeypatch.setattr(module, "_pod_state", module.PodState.SESSION)
+    monkeypatch.setattr(pa, "_thread_id", "thread-1")
+    monkeypatch.setattr(
+        pa, "_canonical_pinned_session_identity_fingerprint", lambda _v: "fp"
+    )
+    monkeypatch.setattr(
+        pa, "_current_pinned_session_identity_fingerprint", lambda: "fp"
+    )
+    monkeypatch.setattr(
+        pa, "_terminate_session", AsyncMock(side_effect=RuntimeError(BOOM))
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post(
+        "/session/detach", json={"session_identity_fingerprint": "fp"}
+    )
+
+    assert response.status_code == 500
+    assert_no_leak(response.json())
+    error_ref_of(response.json())
+
+
+# =============================================================================
+# Reflected XSS — GET /magic/approve/{token}, POST /magic/extend/{token}
+# =============================================================================
+
+
+class _Conn:
+    """Serves the queued rows in order; the queue is shared across acquires."""
+
+    def __init__(self, rows: list):
+        self._rows = rows
+
+    async def fetchrow(self, *_args, **_kwargs):
+        return self._rows.pop(0) if self._rows else None
+
+
+class _DB:
+    def __init__(self, rows: list):
+        self._rows = list(rows)
+
+    def acquire(self):
+        @asynccontextmanager
+        async def _cm():
+            yield _Conn(self._rows)
+
+        return _cm()
+
+
+def _magic_client(
+    monkeypatch, *, tool_name: str = "run_command", rows=None, thread_id=None
+):
+    import orchestrator.main as main
+
+    permission_row = {
+        "id": "perm-1",
+        "tool_name": tool_name,
+        "tool_args": {"cmd": "ls"},
+        "status": "pending",
+    }
+    monkeypatch.setattr(
+        main.headless_notifications,
+        "validate_magic_link",
+        AsyncMock(
+            return_value={
+                "approval_id": "perm-1",
+                "intended_decision": "approved",
+                "thread_id": thread_id,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        main, "postgres_db", _DB(rows if rows is not None else [permission_row])
+    )
+    app = mount_main_routes(["/magic/approve/{token}", "/magic/extend/{token}"])
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_the_confirmation_page_escapes_a_script_payload_in_the_token(monkeypatch):
+    client = _magic_client(monkeypatch)
+
+    response = client.get(f"/magic/approve/{urllib.parse.quote(XSS_PATH, safe='')}")
+
+    assert response.status_code == 200
+    # The token lands in a form ``action`` attribute, where it is sanitized by
+    # percent-encoding: the quote that would close the attribute and the angle
+    # brackets that would open a tag cannot appear raw anywhere in the page.
+    assert XSS_PATH not in response.text
+    assert "onerror=alert(1)" not in response.text
+    assert "%22%3E%3Cimg" in response.text
+
+
+def test_the_confirmation_page_escapes_a_script_payload_in_the_tool_name(monkeypatch):
+    client = _magic_client(monkeypatch, tool_name=XSS)
+
+    response = client.get("/magic/approve/plain-token")
+
+    assert response.status_code == 200
+    assert XSS not in response.text
+    assert "<script>" not in response.text.lower()
+    assert "&lt;script&gt;" in response.text
+
+
+def test_the_extend_page_escapes_a_script_payload_in_the_token(monkeypatch):
+    """``/magic/extend`` re-renders the same page, so the token reflects again.
+
+    A bound ``thread_id`` is required — without one the handler answers 400
+    before rendering. The extend UPDATE returns the bumped row, then the
+    permission row is re-read: two ``fetchrow`` calls, hence two queued rows.
+    """
+    client = _magic_client(
+        monkeypatch,
+        thread_id="11111111-2222-4333-8444-555555555555",
+        rows=[
+            {"extend_count": 1},
+            {
+                "tool_name": "run_command",
+                "tool_args": {"cmd": "ls"},
+                "status": "pending",
+            },
+        ],
+    )
+
+    response = client.post(f"/magic/extend/{urllib.parse.quote(XSS_PATH, safe='')}")
+
+    assert response.status_code == 200
+    assert XSS_PATH not in response.text
+    assert "onerror=alert(1)" not in response.text
+    assert "%22%3E%3Cimg" in response.text

--- a/tests/test_datasources_router_wire.py
+++ b/tests/test_datasources_router_wire.py
@@ -20,6 +20,8 @@ are the ones a handler move can quietly change:
   200 with ``status: error``, while a disabled deployment is still a 403.
 """
 
+import json
+import re
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -545,7 +547,13 @@ def test_probe_of_an_unreachable_postgres_target_is_a_200_error_report():
         AsyncMock(side_effect=OSError("connection refused")),
     ):
         body = wire.client.post(f"/api/datasources/{DATASOURCE_ID}/test").json()
-    assert body == {"status": "error", "message": "connection refused"}
+    # The driver's own text can carry the connection URL (password included),
+    # so it goes to the log and the client gets the code's own wording plus
+    # the correlation id that finds that log line.
+    assert body["status"] == "error"
+    assert body["message"] == "PostgreSQL connection failed"
+    assert "connection refused" not in json.dumps(body)
+    assert re.fullmatch(r"[0-9a-f]{12}", body["error_ref"])
 
 
 def test_probe_of_an_unknown_type_names_the_type():
@@ -586,7 +594,7 @@ def test_probe_of_an_ssh_repository_connector_reports_no_api_probe():
     assert "clone at job start is the test" in body["message"]
 
 
-def test_probe_surfaces_a_gate_crash_as_a_500_with_its_message():
+def test_probe_surfaces_a_gate_crash_as_a_500_without_its_message():
     """The gate resolves the connector *inside* the operation's try/except."""
 
     async def exploding_gate(*_args, **_kwargs):
@@ -595,7 +603,9 @@ def test_probe_surfaces_a_gate_crash_as_a_500_with_its_message():
     wire = _wire(gates={"require_datasource_owner": exploding_gate})
     response = wire.client.post(f"/api/datasources/{DATASOURCE_ID}/test")
     assert response.status_code == 500
-    assert response.json()["detail"] == "pool exhausted"
+    detail = response.json()["detail"]
+    assert "pool exhausted" not in detail
+    assert re.fullmatch(r"Connector test failed \(error_ref=[0-9a-f]{12}\)", detail)
 
 
 # =============================================================================


### PR DESCRIPTION
Closes the 16 `py/stack-trace-exposure` (medium) and 2 `py/reflective-xss` (high) CodeQL findings.

Line numbers in the alerts are from scan revision `92aa27b2`, where `src/orchestrator/main.py` was 71,618
lines. A later restructure moved most of those handlers into `routers/` + `services/`, so most alerts are
fixed where the code lives today. Both `92aa27b2` and `3e0a2939` resolve the reported lines identically,
which is what the drift map below was built from.

## The fix

**Stack traces.** Every affected handler now calls `logger.exception` server-side with a 12-hex-char
`error_ref`, and returns only the message the code composed itself plus that same `error_ref` so an operator
can join the response to the log line. **HTTP status codes and response body shapes are unchanged** — no
client contract moves. Where a handler already had a safe, self-composed message it keeps it; only
`str(exc)` of an arbitrary exception is removed. This follows the existing `_unhandled_exception_handler`
house style rather than introducing a new error envelope.

**HTML escaping.** `_magic_link_confirmation_page` now uses `html.escape(quote=True)` for reflected values and explicitly escapes percent-encoded tokens at both form-action sinks. The previous renderer already escaped `<` and `&` in element content and percent-encoded tokens in attributes. This change makes the escaping complete and explicit for the scanner; the tests do not establish a previously exploitable XSS path. Form POST targets still resolve.

## Per-alert table

| Alert (scan line) | Rule | Route | Change |
|---|---|---|---|
| `main.py:36834` | stack-trace | `POST /api/jobs/{id}/accept` | `services/job_diff_review.py:273` — 503 still names the backend, exception text now logged with `error_ref` |
| `main.py:36959` | stack-trace | `POST /api/jobs/{id}/reject` | historical alert after handler extraction; the current reject handler has no arbitrary backend-exception sink, and typed conflict responses remain unchanged |
| `main.py:39395` | stack-trace | `POST /api/datasources/{id}/test` (kb) | `services/datasources.py` — `_probe_failure("Knowledge base probe failed")` |
| `main.py:39413` | stack-trace | same route (postgresql) | `_probe_failure("PostgreSQL connection failed")` |
| `main.py:39426` | stack-trace | same route (neo4j) | `_probe_failure("Neo4j connection failed")` |
| `main.py:39437` | stack-trace | same route (mongodb) | `_probe_failure("MongoDB connection failed")` |
| `main.py:39453` | stack-trace | same route (webdav) | `_probe_failure("WebDAV connection failed")` |
| `main.py:39471` | stack-trace | same route (email) | `_probe_failure("IMAP/SMTP connection failed")` |
| `main.py:67445` | stack-trace | `POST /api/admin/system-settings/main_cloud/test` | `services/main_cloud_settings.py` — keeps `detail: "build_backend failed"`, adds `error_ref` |
| `main.py:67451` | stack-trace | same route | keeps `detail: "ensure_initialized raised"`, adds `error_ref` |
| `persistent_app.py:6240` | stack-trace | `POST /session/detach` | generic `"session detach failed"` + `error_ref`, 500 held |
| `persistent_app.py:6296` | stack-trace | `POST /cloud-overlay/reset` (`CloudOverlayUnavailable`) | generic message + `error_ref`, 404 held; **had no server-side logging at all** — added |
| `persistent_app.py:6304` | stack-trace | same route (catch-all) | generic `"cloud overlay reset failed"` + `error_ref`, 500 held |
| `dual_app.py:1378` | stack-trace | `POST /system/shell-state` | `{"tabs": [], "message": "Error: shell state unavailable", "error_ref": ...}`, 200 held; **logging added** |
| `dual_app.py:2115` | stack-trace | `POST /session/detach` | generic `"session detach failed"` + `error_ref`, 500 held |
| `app.py:1028` | stack-trace | `POST /system/shell-state` | same shape as `dual_app`; `logger.error` upgraded to `logger.exception` |
| `main.py:59086` | **reflective-xss** | `GET /magic/approve/{token}` | `html.escape(quote=True)` on `safe_tool` / `safe_args`; token escaped at the sink |
| `main.py:59324` | **reflective-xss** | `POST /magic/extend/{token}` | same page renderer, same fix |

Alerts reported against the pre-restructure path `src/api/` are stale duplicates and close when `develop` is
re-analyzed; they are not chased here.

### Deliberately unchanged

`services/job_diff_review.py:414` and `:554` also interpolate an exception, but that exception is
`CompletionControlClaimConflict` — a self-composed 409 vocabulary the cockpit branches on, not arbitrary
exception text. `services/datasources.py:1231/1238` belong to a different handler outside the reported
alerts. No CodeQL suppressions were added.

## Verification

`tests/test_codeql_error_disclosure.py` exercises the affected error handlers and HTML renderer through FastAPI test clients. Error cases assert the established status/body shape, absence of exception text and tracebacks, and a correlation reference. The reject route is checked as an unchanged safe typed-conflict path. HTML cases assert escaped output; they do not demonstrate a previously exploitable XSS path.

Seven existing test expectations were updated across the original fix and closeout. The three cloud-overlay cases reproduced the old CI failures before correction, then retained their 404/500 assertions while requiring the sanitized message, a 12-digit hexadecimal `error_ref`, and absence of the original exception detail. No tests were skipped or deleted.

Current head `e13771d172548d96154a74bf880d786d74ebff99` incorporates develop at `a87464e7b` and preserves both imports involved in the merge conflict (`functools` and `html`). Fresh focused verification:

```text
python -m pytest tests/cloud_overlay/test_overlay_reset.py 
  tests/test_codeql_error_disclosure.py tests/test_datasources_router_wire.py
  tests/test_b04_lane_m_main_cloud_settings_routes.py tests/test_b04_lane_c_job_diff.py
  tests/test_magic_link_pages_branding.py tests/test_job_diff_endpoints.py
  tests/test_job_shell_state_recipient.py -q
215 passed, 2 dependency deprecation warnings in 12.48s

ruff check src/orchestrator/main.py tests/cloud_overlay/test_overlay_reset.py
All checks passed!
```

The updated head received independent review with no blocking findings. Fresh GitHub CI is running. Full-stack live verification has not been completed by the original job and is not claimed here.
