### PR TITLE
fix: make the 26 py/polynomial-redos patterns linear

### DIFF
--- a/src/agent/managers/git_manager.py
+++ b/src/agent/managers/git_manager.py
@@ -1722,7 +1722,11 @@ class GitManager:
         """Mask credentials in a URL for safe logging."""
         import re
 
-        return re.sub(r"://([^:]+):[^@]+@", r"://\1:***@", url)
+        # "/" and "@" are excluded from both halves of the userinfo: they can
+        # only appear percent-encoded there, and letting them through meant a
+        # run of "://" markers made every one of them rescan the rest of the
+        # URL for an "@" that never came (quadratic on hostile input).
+        return re.sub(r"://([^:@/]+):[^@/]+@", r"://\1:***@", url)
 
     def _mask_url(self, url: str) -> str:
         """Instance method wrapper for URL masking."""

--- a/src/orchestrator/services/email_markdown.py
+++ b/src/orchestrator/services/email_markdown.py
@@ -74,13 +74,28 @@ _HEADINGS = {
 }
 _HEADING_FALLBACK = ("15px", "21px", "14px 0 6px 0")
 
-_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*[^\s`]*\s*$")
-_HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
+# Every pattern below scans a line of an untrusted, model-authored body, so each
+# is written to stay linear: no two adjacent parts may match the same character,
+# and nothing that can fail follows a run these patterns have to re-partition.
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(?:[^\s`]+\s*)?$")
+# An ATX closing run ("## Done ##") is trimmed by _atx_text rather than by a
+# "(.*?)\s*#*\s*$" tail, which offered three ways to split the same whitespace.
+_HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.*)")
 _HR_RE = re.compile(r"^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$")
 _QUOTE_RE = re.compile(r"^ {0,3}>[ \t]?(.*)$")
-_UL_RE = re.compile(r"^( *)([-*+])[ \t]+(.*)$")
-_OL_RE = re.compile(r"^( *)(\d{1,9})[.)][ \t]+(.*)$")
+# No trailing "$": "." already stops at a newline and every caller passes a
+# single line, so the anchor only gave the marker's whitespace run something to
+# backtrack against.
+_UL_RE = re.compile(r"^( *)([-*+])[ \t]+(.*)")
+_OL_RE = re.compile(r"^( *)(\d{1,9})[.)][ \t]+(.*)")
 _SAFE_SCHEME_RE = re.compile(r"^(?:https?://|mailto:)", re.IGNORECASE)
+# "[label](dest)". Neither the label nor the destination may contain "[", so a
+# run of unclosed openers costs each attempt only the distance to the next one
+# instead of a scan of the whole remaining text. A "[" is not legal unescaped in
+# a URL and a label's own brackets were already cut short by the "]" terminator.
+_LINK_RE = re.compile(
+    r"\[([^\[\]\n]*)\]\([ \t]*<?([^)\s<>\[]+)>?(?:[ \t]+&quot;[^)\n]*&quot;)?[ \t]*\)"
+)
 
 # Nesting past this renders as flat paragraphs -- see _parse_blocks.
 _MAX_DEPTH = 12
@@ -135,7 +150,8 @@ def _parse_blocks(lines: list[str], depth: int = 0) -> list[tuple[str, str]]:
             blocks.append(("html", _thematic_break()))
             i += 1
         elif heading := _HEADING_RE.match(line):
-            blocks.append(("html", _heading(len(heading.group(1)), heading.group(2))))
+            text = _atx_text(heading.group(2))
+            blocks.append(("html", _heading(len(heading.group(1)), text)))
             i += 1
         elif _QUOTE_RE.match(line):
             inner, i = _consume_quote(lines, i)
@@ -338,6 +354,17 @@ def _consume_table(lines: list[str], start: int) -> tuple[str, int]:
     )
 
 
+def _atx_text(text: str) -> str:
+    """Heading text minus its optional closing run of hashes ("## Done ##").
+
+    `_HEADING_RE` used to trim that run with a `(.*?)\\s*#*\\s*$` tail, which
+    gave the engine three overlapping ways to split the same trailing
+    whitespace -- quadratic on a hostile line. Two rstrips cost one pass.
+    """
+    text = text.rstrip()
+    return text.rstrip("#").rstrip() if text.endswith("#") else text
+
+
 def _heading(level: int, text: str) -> str:
     size, line_height, margin = _HEADINGS.get(level, _HEADING_FALLBACK)
     tag = f"h{min(level + 1, 6)}"
@@ -409,21 +436,67 @@ def _inline(text: str) -> str:
         lambda m: keep(html.escape(m.group(1), quote=True)),
         text,
     )
-    text = re.sub(r"(`+)([\s\S]+?)\1", lambda m: keep(_code_span(m.group(2))), text)
+    text = _sub_code_spans(text, lambda inner: keep(_code_span(inner)))
     text = re.sub(
         r"<((?:https?://|mailto:)[^\s<>]+)>",
         lambda m: keep(_anchor(m.group(1), html.escape(m.group(1), quote=True))),
         text,
     )
     text = html.escape(text, quote=True)
-    text = re.sub(
-        r"\[([^\]\n]*)\]\(\s*<?([^)\s<>]+)>?(?:\s+&quot;[^)\n]*&quot;)?\s*\)",
+    text = _LINK_RE.sub(
         lambda m: keep(_anchor(html.unescape(m.group(2)), _emphasis(m.group(1)))),
         text,
     )
     text = _BARE_URL_RE.sub(_bare_url(keep), text)
     text = _emphasis(text)
     return _restore(text.replace("\n", "<br>"), tokens)
+
+
+def _sub_code_spans(text: str, render) -> str:
+    """Replace `` `code` `` spans, matching each run of backticks to the next run
+    of the same length.
+
+    The pattern this replaces, ``(`+)([\\s\\S]+?)\\1``, restarts a lazy scan of
+    the whole remaining text at every backtick run that never finds its partner,
+    which is quadratic in the number of runs. One left-to-right pass costs the
+    same on ordinary input and cannot be made to backtrack.
+    """
+    if "`" not in text:
+        return text
+    out: list[str] = []
+    i = 0
+    length = len(text)
+    while i < length:
+        start = text.find("`", i)
+        if start < 0:
+            out.append(text[i:])
+            break
+        run = start
+        while run < length and text[run] == "`":
+            run += 1
+        width = run - start
+        # The closing run must be exactly `width` backticks, as in CommonMark.
+        search = run
+        close = -1
+        while search < length:
+            candidate = text.find("`" * width, search)
+            if candidate < 0:
+                break
+            end = candidate
+            while end < length and text[end] == "`":
+                end += 1
+            if end - candidate == width:
+                close = candidate
+                break
+            search = end
+        if close < 0:
+            out.append(text[i:run])
+            i = run
+            continue
+        out.append(text[i:start])
+        out.append(render(text[run:close]))
+        i = close + width
+    return "".join(out)
 
 
 def _bare_url(keep):
@@ -473,15 +546,25 @@ def _emphasis(text: str) -> str:
 
     The `_` variants require a non-word character on both sides, or every
     `snake_case_identifier` in an agent message turns into italics."""
+    # "(.+?)" spanning a "**" of its own is what made these quadratic: every
+    # opener lazily rescanned the rest of the line, and a closer rejected by the
+    # lookarounds sent it back to the next opener. A span that cannot contain
+    # its own delimiter gives each character one chance to be consumed.
     text = re.sub(
-        r"(?<!\*)\*\*(?!\s)(.+?)(?<!\s)\*\*(?!\*)", r"<strong>\1</strong>", text
+        r"(?<!\*)\*\*(?!\s)((?:[^*\n]|\*(?!\*))+)(?<!\s)\*\*(?!\*)",
+        r"<strong>\1</strong>",
+        text,
     )
     text = re.sub(
-        r"(?<![\w_])__(?!\s)(.+?)(?<!\s)__(?!\w)", r"<strong>\1</strong>", text
+        r"(?<![\w_])__(?!\s)((?:[^_\n]|_(?!_))+)(?<!\s)__(?!\w)",
+        r"<strong>\1</strong>",
+        text,
     )
     text = re.sub(r"(?<![\*\w])\*(?!\s)([^*\n]+?)(?<!\s)\*(?!\*)", r"<em>\1</em>", text)
     text = re.sub(r"(?<![\w_])_(?!\s)([^_\n]+?)(?<!\s)_(?!\w)", r"<em>\1</em>", text)
-    return re.sub(r"~~(?!\s)(.+?)(?<!\s)~~", r"<s>\1</s>", text)
+    # Not flagged by CodeQL, but the same "(.+?)" shape as the two above and
+    # measurably quadratic on a run of unclosed "~~" openers.
+    return re.sub(r"~~(?!\s)((?:[^~\n]|~(?!~))+)(?<!\s)~~", r"<s>\1</s>", text)
 
 
 def _restore(text: str, tokens: list[str]) -> str:

--- a/src/orchestrator/services/kb_reindex.py
+++ b/src/orchestrator/services/kb_reindex.py
@@ -182,7 +182,11 @@ _DEFAULT_PRIORITY_RANK = 1
 _NOTE_ID_MAX = 100
 _CONFIDENCE_MAX = 20
 
-_H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+# The trailing "\s*$" is gone: a lazy "(.+?)" followed by an optional whitespace
+# run gave the engine a fresh way to split every trailing space on a hostile
+# line. "." already stops at the newline, so the title is trimmed at the call
+# site instead -- the same shape knowledge/gardener.py:_H1_RE already uses.
+_H1_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
 
 
 def normalize_root_path(root_path: Optional[str]) -> str:
@@ -329,7 +333,7 @@ def note_fields(path: str, fm: Optional[Dict[str, Any]], body: str) -> Dict[str,
     note_id = str(fm.get("id") or stem)[:_NOTE_ID_MAX]
 
     m = _H1_RE.search(body or "")
-    title = m.group(1) if m else note_id
+    title = m.group(1).rstrip() if m else note_id
 
     note_type = str(fm.get("type", "")).strip().lower()
     if note_type not in VALID_NOTE_TYPES:

--- a/src/orchestrator/services/tts.py
+++ b/src/orchestrator/services/tts.py
@@ -1423,8 +1423,12 @@ def _strip_markdown_for_speech(text: str) -> str:
     t = re.sub(r"```[\s\S]*?```", " (code snippet) ", t)
     t = re.sub(r"~~~[\s\S]*?~~~", " (code snippet) ", t)
     # Images ![alt](url) → drop; links [text](url) → text; inline `code` → code.
-    t = re.sub(r"!\[[^\]]*\]\([^)]*\)", " ", t)
-    t = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", t)
+    # "[" is excluded from the label and the destination so a run of unclosed
+    # "[a](" openers cannot make each attempt rescan the whole remaining text
+    # (quadratic on hostile input). An unescaped "[" is not legal in a URL, and
+    # a label's own bracket was already cut short by the "]" terminator.
+    t = re.sub(r"!\[[^\]\[\n]*\]\([^)\[\n]*\)", " ", t)
+    t = re.sub(r"\[([^\]\[\n]*)\]\([^)\[\n]*\)", r"\1", t)
     t = re.sub(r"`([^`]*)`", r"\1", t)
 
     # Line-oriented cleanup: tables → "cell, cell." sentences, and strip leading

--- a/src/shared/runtime/core/managed_repository.py
+++ b/src/shared/runtime/core/managed_repository.py
@@ -555,7 +555,10 @@ def repository_url_has_credentials(value: Any) -> bool:
     parsed = urlparse(text)
     if parsed.scheme:
         return parsed.username is not None or parsed.password is not None
-    return bool(re.match(r"^[^/\\\s]+@[^:]+:", text))
+    # "@" is excluded from the identity run so it cannot also be consumed by the
+    # host run that follows: overlapping on every "@" made a string of them cost
+    # quadratic time. An scp-style identity never contains one.
+    return bool(re.match(r"^[^/\\\s@]+@[^:]+:", text))
 
 
 def _wipe_validated_private_keys(validated: Iterable[dict[str, Any]]) -> None:

--- a/src/shared/runtime/knowledge/chunker.py
+++ b/src/shared/runtime/knowledge/chunker.py
@@ -44,7 +44,11 @@ OVERLAP_RATIO = 0.12
 # raise via env for providers with roomier limits.
 DEFAULT_MAX_EMBED_BATCH = int(os.getenv("EMBEDDING_MAX_BATCH", "64"))
 
-_HEADING_LINE_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+# No trailing "$": it is redundant for the single lines _split_sections feeds in
+# ("." already stops at a newline), and it was the only thing that could fail
+# after "\s+" -- the ambiguity between that run and "(.*)" is what the scanner
+# flagged.
+_HEADING_LINE_RE = re.compile(r"^(#{1,6})\s+(.*)")
 _PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n")
 
 

--- a/src/shared/runtime/knowledge/gardener.py
+++ b/src/shared/runtime/knowledge/gardener.py
@@ -30,7 +30,10 @@ _MD_LINK_RE = re.compile(r"(?<!\!)\[[^\]]*\]\(([^)]+)\)")
 # the markdown rule above. This vault is an Obsidian vault — wikilinks are the
 # dominant link syntax, so a parser that only knew _MD_LINK_RE saw a small
 # fraction of the real graph.
-_WIKILINK_RE = re.compile(r"(?<!\!)\[\[([^\]]+)\]\]")
+# "[" is excluded from the target as well as "]": a body full of unclosed "[["
+# openers otherwise made every one of them rescan the rest of the text for a
+# closing "]]", which is quadratic. No wikilink target contains a bracket.
+_WIKILINK_RE = re.compile(r"(?<!\!)\[\[([^\]\[]+)\]\]")
 # ATX heading anywhere in the body.
 _HEADING_RE = re.compile(r"^#{1,6}\s", re.MULTILINE)
 

--- a/tests/test_redos_linearity.py
+++ b/tests/test_redos_linearity.py
@@ -1,0 +1,241 @@
+"""The regexes reached by untrusted text run in linear time.
+
+CodeQL's ``py/polynomial-redos`` flagged 26 sites where a pattern applied to
+user-provided text backtracks polynomially: an email body, a knowledge note, a
+repository URL or a line of git output can be shaped so one ``re`` call spends
+seconds of CPU. On a multi-tenant service that is a denial-of-service vector,
+so each site below carries two kinds of test:
+
+  * **Characterization** — the behaviour on ordinary input, pinned before the
+    rewrite so a faster pattern cannot quietly become a different one.
+  * **Adversarial** — the hostile shape that made the *original* pattern
+    quadratic, at ``HOSTILE`` characters, asserted to finish inside ``BUDGET``.
+
+The adversarial bound is wall-clock, which is not perfectly reproducible, but
+the margin is what makes it meaningful: every original pattern here needed tens
+of seconds (two ran past 60s) on the same input this file completes in
+milliseconds. A regression would miss the bound by orders of magnitude, not by
+a few percent.
+"""
+
+import time
+
+import pytest
+
+from agent.managers.git_manager import GitManager
+from orchestrator.services import email_markdown as em
+from orchestrator.services import kb_reindex, tts
+from shared.runtime.core.managed_repository import repository_url_has_credentials
+from shared.runtime.knowledge import chunker, gardener
+
+# The brief's floor: a hostile input of at least 100 000 characters.
+HOSTILE = 100_000
+# "Well under a second" — the original patterns needed 30-60+ seconds here.
+BUDGET = 1.0
+
+
+def assert_fast(fn, arg, budget: float = BUDGET):
+    """Run `fn(arg)` and fail if it took longer than `budget` seconds.
+
+    The argument is built by the caller, so construction cost stays out of the
+    measurement and the number is the scan itself.
+    """
+    start = time.perf_counter()
+    result = fn(arg)
+    elapsed = time.perf_counter() - start
+    assert elapsed < budget, f"{fn} took {elapsed:.3f}s on {len(arg)} chars"
+    return result
+
+
+class TestEmailMarkdownBlocks:
+    """Block scanners in the email renderer (alerts #466-#479).
+
+    Every one of these runs per line of an agent-authored message, and
+    ``_starts_block`` runs all of them on the same line again.
+    """
+
+    def test_fence_openers_are_recognized(self) -> None:
+        assert em._FENCE_RE.match("```python").group(1) == "```"
+        assert em._FENCE_RE.match("   ~~~~").group(1) == "~~~~"
+        # Four spaces is an indented code block, not a fence.
+        assert em._FENCE_RE.match("    ```") is None
+
+    def test_headings_keep_their_level_and_text(self) -> None:
+        assert em._HEADING_RE.match("## Status").groups() == ("##", "Status")
+        assert em._HEADING_RE.match("#Nospace") is None
+        # A closing run of hashes is decoration, not part of the text. The trim
+        # moved out of the pattern's tail into _atx_text; the text is the same.
+        heading = em._HEADING_RE.match("### Done ###")
+        assert heading.group(1) == "###"
+        assert em._atx_text(heading.group(2)) == "Done"
+        assert em._atx_text("A ### B ###") == "A ### B"
+        assert em._atx_text("plain") == "plain"
+
+    def test_list_markers_keep_indent_and_content(self) -> None:
+        assert em._UL_RE.match("- item").groups() == ("", "-", "item")
+        assert em._UL_RE.match("  * nested").groups() == ("  ", "*", "nested")
+        assert em._UL_RE.match("-nospace") is None
+        assert em._OL_RE.match("3. third").groups() == ("", "3", "third")
+        assert em._OL_RE.match("  10) ten").groups() == ("  ", "10", "ten")
+
+    def test_a_realistic_message_still_renders(self) -> None:
+        html = em.render_markdown(
+            "# Job complete\n\n"
+            "Ran `pytest` **twice**:\n\n"
+            "- `tests/test_a.py` — 12 passed\n"
+            "- `tests/test_b.py` — 3 passed\n\n"
+            "> No regressions.\n\n"
+            "See https://example.invalid/runs/1 for the log.\n"
+        )
+        assert "<h2" in html and html.count("<li") == 2
+        assert "<strong>twice</strong>" in html
+        assert "<blockquote" in html or "<table" in html
+
+    def test_fence_info_string_run_is_linear(self) -> None:
+        # "\s*[^\s`]*\s*$": two whitespace runs around an optional info word.
+        assert_fast(em._FENCE_RE.match, "```" + " " * HOSTILE + "`")
+
+    def test_heading_trailing_hash_run_is_linear(self) -> None:
+        # "(.*?)\s*#*\s*$": three overlapping ways to split one tail.
+        half = HOSTILE // 2
+        assert_fast(em._HEADING_RE.match, "# h" + " " * half + "#" + " " * half + "x")
+
+    def test_starts_block_runs_every_scanner_linearly(self) -> None:
+        half = HOSTILE // 2
+        line = "# h" + " " * half + "#" + " " * half + "x"
+        assert_fast(lambda s: em._starts_block([s], 0), line)
+
+    def test_unordered_marker_whitespace_run_is_linear(self) -> None:
+        # "[ \t]+(.*)$" overlap; the newline makes the anchor fail.
+        assert_fast(em._UL_RE.match, "- " + " " * HOSTILE + "\nX")
+
+    def test_ordered_marker_whitespace_run_is_linear(self) -> None:
+        assert_fast(em._OL_RE.match, "1. " + " " * HOSTILE + "\nX")
+
+
+class TestEmailMarkdownInline:
+    """Inline rendering of an untrusted message body (alerts #480-#483)."""
+
+    def test_code_spans_and_links_render(self) -> None:
+        html = em._inline("call `run()` in [the docs](https://example.invalid/d)")
+        assert ">run()</code>" in html
+        assert 'href="https://example.invalid/d"' in html
+        assert ">the docs</a>" in html
+
+    def test_emphasis_renders(self) -> None:
+        assert em._emphasis("**bold**") == "<strong>bold</strong>"
+        assert em._emphasis("__bold__") == "<strong>bold</strong>"
+        assert em._emphasis("*it*") == "<em>it</em>"
+        assert em._emphasis("~~gone~~") == "<s>gone</s>"
+        # snake_case identifiers must not turn into italics.
+        assert em._emphasis("a_b_c") == "a_b_c"
+
+    def test_unclosed_code_fences_are_linear(self) -> None:
+        # "(`+)([\s\S]+?)\1": each unclosed fence rescanned the whole tail.
+        assert_fast(em._inline, "``" * (HOSTILE // 8) + "a" * HOSTILE)
+
+    def test_unclosed_link_openers_are_linear(self) -> None:
+        # Each "[a](" opener rescanned the tail looking for ")".
+        assert_fast(em._inline, "[a](" * (HOSTILE // 4))
+
+    def test_unclosed_star_emphasis_is_linear(self) -> None:
+        # Every opener scans to EOL; every candidate closer is rejected by the
+        # preceding space, so the scan restarts at the next opener.
+        assert_fast(em._emphasis, " **a" * (HOSTILE // 4))
+
+    def test_unclosed_underscore_emphasis_is_linear(self) -> None:
+        assert_fast(em._emphasis, " __a" * (HOSTILE // 4))
+
+
+class TestTtsMarkdownStripping:
+    """Speech normalisation of message content (alerts #488-#490)."""
+
+    def test_ordinary_markdown_becomes_speakable(self) -> None:
+        spoken = tts._strip_markdown_for_speech(
+            "## Result\n\n"
+            "See ![chart](c.png) and [the run](https://example.invalid/r).\n\n"
+            "- first\n"
+            "1. second\n\n"
+            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n"
+            "```\ncode()\n```\n"
+        )
+        assert "Result" in spoken
+        assert "the run" in spoken and "https://example.invalid/r" not in spoken
+        assert "chart" not in spoken  # images drop entirely
+        assert "first" in spoken and "second" in spoken
+        assert "(code snippet)" in spoken
+        assert "|" not in spoken and "#" not in spoken
+
+    def test_unclosed_image_openers_are_linear(self) -> None:
+        assert_fast(tts._strip_markdown_for_speech, "![a](" * (HOSTILE // 5))
+
+    def test_unclosed_link_openers_are_linear(self) -> None:
+        assert_fast(tts._strip_markdown_for_speech, "[a](" * (HOSTILE // 4))
+
+    def test_leading_marker_whitespace_run_is_linear(self) -> None:
+        assert_fast(tts._strip_markdown_for_speech, " \t" * (HOSTILE // 2) + "1x")
+
+
+class TestKnowledgeNoteParsing:
+    """Note titles and section splitting (alerts #465, #486, #484)."""
+
+    def test_h1_title_is_extracted_and_stripped(self) -> None:
+        assert kb_reindex._H1_RE.search("# Weekly report  \n\nbody").group(1) == (
+            "Weekly report"
+        )
+        assert gardener.note_title("# Weekly report\n\nbody") == "Weekly report"
+
+    def test_sections_split_on_heading_breadcrumbs(self) -> None:
+        assert chunker._split_sections("pre\n\n# A\n\ntext\n\n## B\n\nmore") == [
+            (None, "pre"),
+            ("A", "# A\n\ntext"),
+            ("A > B", "## B\n\nmore"),
+        ]
+
+    def test_wikilink_targets_drop_aliases_anchors_and_embeds(self) -> None:
+        body = "see [[alpha|A]] and ![[embed]] and [[b#s]] and [x](n.md)"
+        assert gardener._WIKILINK_RE.findall(body) == ["alpha|A", "b#s"]
+        assert gardener._internal_link_targets(body) == ["n", "alpha", "b"]
+
+    def test_h1_trailing_whitespace_run_is_linear(self) -> None:
+        # "^#\s+(.+?)\s*$" under MULTILINE: the trailing "\s*" re-split the run.
+        assert_fast(kb_reindex._H1_RE.search, "# t" + " " * HOSTILE + "x")
+
+    def test_heading_whitespace_run_is_linear(self) -> None:
+        assert_fast(chunker._split_sections, "#" + " \t" * (HOSTILE // 2) + "x")
+
+    def test_unclosed_wikilink_openers_are_linear(self) -> None:
+        # Each "[[" rescanned the tail for a closing "]]".
+        assert_fast(gardener._WIKILINK_RE.search, "[[" * (HOSTILE // 2))
+
+
+class TestRepositoryUrls:
+    """Repository identities from user-supplied config (alerts #485, #487)."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://user:pass@github.invalid/o/r.git", True),
+            ("git@github.invalid:owner/repo.git", True),  # scp-style
+            ("ssh://git@github.invalid/o/r.git", True),
+            ("https://github.invalid/owner/repo.git", False),
+            ("", False),
+        ],
+    )
+    def test_credential_detection(self, url: str, expected: bool) -> None:
+        assert repository_url_has_credentials(url) is expected
+
+    def test_url_masking_hides_only_the_secret(self) -> None:
+        masked = GitManager._mask_url_static("https://user:tok@github.invalid/o/r.git")
+        assert masked == "https://user:***@github.invalid/o/r.git"
+        assert GitManager._mask_url_static("https://github.invalid/o/r.git") == (
+            "https://github.invalid/o/r.git"
+        )
+
+    def test_at_sign_run_is_linear(self) -> None:
+        # "^[^/\\\s]+@[^:]+:": the two runs overlap on every "@".
+        assert_fast(repository_url_has_credentials, "a@" * (HOSTILE // 2))
+
+    def test_scheme_marker_run_is_linear(self) -> None:
+        # "://([^:]+):[^@]+@": each "://" rescanned the tail for an "@".
+        assert_fast(GitManager._mask_url_static, "://a" * (HOSTILE // 4))

--- a/tests/test_redos_linearity.py
+++ b/tests/test_redos_linearity.py
@@ -180,9 +180,11 @@ class TestKnowledgeNoteParsing:
     """Note titles and section splitting (alerts #465, #486, #484)."""
 
     def test_h1_title_is_extracted_and_stripped(self) -> None:
-        assert kb_reindex._H1_RE.search("# Weekly report  \n\nbody").group(1) == (
-            "Weekly report"
-        )
+        # The trailing-whitespace trim moved out of _H1_RE's tail into the call
+        # site; the stored title is unchanged, trailing spaces and all.
+        fields = kb_reindex.note_fields("notes/n.md", {}, "# Weekly report  \n\nbody")
+        assert fields["title"] == "Weekly report"
+        assert kb_reindex.note_fields("notes/n.md", {}, "no heading\n")["title"] == "n"
         assert gardener.note_title("# Weekly report\n\nbody") == "Weekly report"
 
     def test_sections_split_on_heading_breadcrumbs(self) -> None:


### PR DESCRIPTION
Repair the polynomial-time text processing behind the 26 original `py/polynomial-redos` alerts, including remaining cases found during closeout review. These paths process email text, speech input, knowledge notes and repository URLs supplied by users or agents.

## Changes

| Sites / original alerts | Final approach |
|---|---|
| Email fence and block markers, #466–#479 | Remove overlapping trailing-whitespace partitions and redundant anchors; require the complete tilde delimiter run before parsing its info string. |
| Email code spans, #480 | Index backtick runs and each run's next same-width partner in two linear passes; unmatched widths do not rescan the suffix. |
| Email links, #481 | Bound candidate and destination parsing; cache title-ending positions so repeated malformed title openers do not repeatedly scan the same tail. Preserve bracketed titles and valid IPv6 authorities. |
| Email emphasis, #482–#483 | Prevent spans from repeatedly consuming their own delimiters. Apply the same repair to strikethrough. |
| Knowledge headings, #465 and #486 | Remove ambiguous/redundant regex tails and trim heading text at the call site. |
| Knowledge links, #484 | Bound wikilink matching and the markdown-link scan that runs before it in `_internal_link_targets`; preserve IPv6 URL authorities. |
| Repository credential detection/masking, #485 and #487 | Remove overlapping separator classes so failed candidates cannot rescan arbitrary tails. |
| TTS, #488–#490 | Bound image/link candidates while preserving IPv6 destinations. Already-linear line-marker stripping remains unchanged. |

No CodeQL suppressions or dependency changes. Code-span pairing uses exact delimiter-run widths. The closeout repair restores valid IPv6 URLs that the first PR head accidentally treated as literal Markdown.

## Verification

Current head: `71c916849b9086482a590558ebdc6b18506b25c8`.

- **455 focused tests passed** across email Markdown, TTS, knowledge chunking/gardening/reindexing, repository authority and regression tests.
- The new tests reproduced the old tilde/link timeouts, excessive code-span growth, IPv6 regressions and the stalled actual knowledge-link caller before repair. Potentially slow cases run in subprocesses with bounded timeouts; growth checks include a noise floor.
- 20,000 deterministic generated link cases matched the preceding parser's behavior, aside from intentionally restored IPv6 support.
- Ruff format/check and whitespace checks passed.

Fresh hostile-input measurements on the repaired head:

| Operation | Input length | Time |
|---|---:|---:|
| Tilde fence followed by a backtick | 100,001 | 0.00094 s |
| Repeated unclosed quoted links | 600,000 | 0.164 s |
| Increasing unmatched backtick widths and a long tail | 960,399 | 0.00475 s |
| Actual knowledge-link caller on repeated `[[` | 200,000 | 0.00710 s |

Fresh GitHub analysis is required before claiming all original alert instances closed. The original job did not finish its full-stack verification report; no live-deployment result is claimed for this repaired head.

A separate pre-existing quadratic loop in bare-URL trailing-punctuation trimming is recorded in `knowledge/issues/email_bare_url_trailing_punctuation_quadratic.md`. It is outside the original alert instances; this PR does not claim that every renderer path is linear.
